### PR TITLE
Do not use deprecated status_endpoint property

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -9,4 +9,8 @@ repositories {
 
 dependencies {
     compile 'com.transloadit.sdk:transloadit:0.1.1'
+    // Uncomment following line if you want to use the local java-sdk
+    // for the example instead of pulling the JARs from JCenter.
+    // This is useful for debugging and testing new features.
+    //compile rootProject
 }

--- a/src/main/java/com/transloadit/sdk/response/AssemblyResponse.java
+++ b/src/main/java/com/transloadit/sdk/response/AssemblyResponse.java
@@ -7,11 +7,8 @@ import org.json.JSONArray;
  * An AssemblyApi tailored Http Response
  */
 public class AssemblyResponse extends Response {
-    protected boolean usesTus;
-
     public AssemblyResponse(okhttp3.Response response, boolean usesTus) throws LocalOperationException {
         super(response);
-        this.usesTus = usesTus;
     }
 
     public AssemblyResponse(okhttp3.Response response) throws LocalOperationException {
@@ -23,7 +20,7 @@ public class AssemblyResponse extends Response {
      * @return assembly id
      */
     public String getId() {
-        return this.json().getString( usesTus ? "id" : "assembly_id");
+        return this.json().getString("assembly_id");
     }
 
     /**
@@ -31,7 +28,7 @@ public class AssemblyResponse extends Response {
      * @return assembly url
      */
     public String getUrl() {
-        return this.json().getString(usesTus ? "status_endpoint" : "assembly_url");
+        return this.json().getString( "assembly_url");
     }
 
     /**
@@ -39,7 +36,7 @@ public class AssemblyResponse extends Response {
      * @return assembly ssl url
      */
     public String getSslUrl() {
-        return this.json().getString(usesTus ? "status_endpoint" : "assembly_ssl_url");
+        return this.json().getString("assembly_ssl_url");
     }
 
     /**

--- a/src/test/java/com/transloadit/sdk/AssemblyTest.java
+++ b/src/test/java/com/transloadit/sdk/AssemblyTest.java
@@ -116,7 +116,7 @@ public class AssemblyTest extends MockHttpService {
                 .respond(HttpResponse.response().withBody(getJson("resumable_assembly.json")));
 
         AssemblyResponse resumableAssembly = assembly.save(true);
-        assertEquals(resumableAssembly.json().get("id"), "02ce6150ea2811e6a35a8d1e061a5b71");
+        assertEquals(resumableAssembly.json().get("assembly_id"), "02ce6150ea2811e6a35a8d1e061a5b71");
     }
 
     @Test
@@ -132,6 +132,6 @@ public class AssemblyTest extends MockHttpService {
                 .respond(HttpResponse.response().withBody(getJson("resumable_assembly.json")));
 
         AssemblyResponse resumableAssembly = assembly.save(true);
-        assertEquals(resumableAssembly.json().get("id"), "02ce6150ea2811e6a35a8d1e061a5b71");
+        assertEquals(resumableAssembly.json().get("assembly_id"), "02ce6150ea2811e6a35a8d1e061a5b71");
     }
 }

--- a/src/test/java/com/transloadit/sdk/async/AsyncAssemblyTest.java
+++ b/src/test/java/com/transloadit/sdk/async/AsyncAssemblyTest.java
@@ -62,7 +62,7 @@ public class AsyncAssemblyTest extends MockHttpService {
         synchronized (listener) {
             listener.wait(3000);
         }
-        assertEquals(resumableAssembly.json().get("id"), "76fe5df1c93a0a530f3e583805cf98b4");
+        assertEquals(resumableAssembly.json().get("assembly_id"), "76fe5df1c93a0a530f3e583805cf98b4");
         assertTrue(uploadFinished);
         assertTrue(assemblyFinished);
         assertEquals(1077, totalUploaded);
@@ -79,7 +79,7 @@ public class AsyncAssemblyTest extends MockHttpService {
         synchronized (listener) {
             listener.wait(3000);
         }
-        assertEquals(resumableAssembly.json().get("id"), "76fe5df1c93a0a530f3e583805cf98b4");
+        assertEquals(resumableAssembly.json().get("assembly_id"), "76fe5df1c93a0a530f3e583805cf98b4");
         assertFalse(uploadFinished);
         assertFalse(assemblyFinished);
         assertNotEquals(1077, totalUploaded);
@@ -98,7 +98,7 @@ public class AsyncAssemblyTest extends MockHttpService {
         synchronized (listener) {
             listener.wait(3000);
         }
-        assertEquals(resumableAssembly.json().get("id"), "76fe5df1c93a0a530f3e583805cf98b4");
+        assertEquals(resumableAssembly.json().get("assembly_id"), "76fe5df1c93a0a530f3e583805cf98b4");
         assertTrue(uploadFinished);
         assertEquals(1077, totalUploaded);
         assertNull(uploadError);
@@ -125,7 +125,7 @@ public class AsyncAssemblyTest extends MockHttpService {
         synchronized (listener) {
             listener.wait(3000);
         }
-        assertEquals(resumableAssembly.json().get("id"), "76fe5df1c93a0a530f3e583805cf98b4");
+        assertEquals(resumableAssembly.json().get("assembly_id"), "76fe5df1c93a0a530f3e583805cf98b4");
         assertEquals(MockAsyncAssembly.State.PAUSED, assembly.state);
 
         // expect the states to not have updated after 5 seconds of wait

--- a/src/test/resources/__files/async_resumable_assembly.json
+++ b/src/test/resources/__files/async_resumable_assembly.json
@@ -1,4 +1,9 @@
 {
-  "id": "76fe5df1c93a0a530f3e583805cf98b4",
-  "status_endpoint": "http://localhost:9040/assemblies/76fe5df1c93a0a530f3e583805cf98b4"
+  "ok": "ASSEMBLY_UPLOADING",
+  "http_code": 200,
+  "message": "The assembly is still in the process of being uploaded.",
+  "assembly_id": "76fe5df1c93a0a530f3e583805cf98b4",
+  "instance": "dara.transloadit.com",
+  "assembly_url": "http://localhost:9040/assemblies/76fe5df1c93a0a530f3e583805cf98b4",
+  "assembly_ssl_url": "http://localhost:9040/assemblies/76fe5df1c93a0a530f3e583805cf98b4"
 }

--- a/src/test/resources/__files/resumable_assembly.json
+++ b/src/test/resources/__files/resumable_assembly.json
@@ -1,4 +1,9 @@
 {
-  "id": "02ce6150ea2811e6a35a8d1e061a5b71",
-  "status_endpoint": "https://api2-kerrigan.transloadit.com/assemblies/02ce6150ea2811e6a35a8d1e061a5b71"
+  "ok": "ASSEMBLY_UPLOADING",
+  "http_code": 200,
+  "message": "The assembly is still in the process of being uploaded.",
+  "assembly_id": "02ce6150ea2811e6a35a8d1e061a5b71",
+  "instance": "dara.transloadit.com",
+  "assembly_url": "http://api2-kerrigan.transloadit.com/assemblies/02ce6150ea2811e6a35a8d1e061a5b71",
+  "assembly_ssl_url": "https://api2-kerrigan.transloadit.com/assemblies/02ce6150ea2811e6a35a8d1e061a5b71"
 }


### PR DESCRIPTION
When we first added tus to Transloadit, the response for creating a tus assembly only contained the id and status_endpoint properties. Therefore it was necessary to differentiate between normal and tus assembly for retrieving the assembly id or assembly url.

However, since then we have changed the api2 to return the normal assembly status when you create a new tus assembly. The status_endpoint and id properties are still added for backwards compatibility but they should not be used anymore, in the hopes that we can remove them at some point in the future.

This PR changes the internals to never use status_endpoint. I hope I did everything alright :)