### PR TITLE
Don't pass a steps object if there are no additional steps. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.1.6 / 2021-02-24 ###
+
+* Fix bug that doesn't allow usage of templates that have disabled allow steps override. 
+
 ### 0.1.5 / 2019-07-16 ###
 
 * Make tus uploads to assembly's tus url

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ or can be installed from the Maven and Jcenter repositories.
 **Gradle:**
 
 ```groovy
-compile 'com.transloadit.sdk:transloadit:0.1.5'
+compile 'com.transloadit.sdk:transloadit:0.1.6'
 ```
 
 **Maven:**
@@ -27,7 +27,7 @@ compile 'com.transloadit.sdk:transloadit:0.1.5'
 <dependency>
   <groupId>com.transloadit.sdk</groupId>
   <artifactId>transloadit</artifactId>
-  <version>0.1.5</version>
+  <version>0.1.6</version>
 </dependency>
 ```
 

--- a/src/main/java/com/transloadit/sdk/Assembly.java
+++ b/src/main/java/com/transloadit/sdk/Assembly.java
@@ -187,7 +187,9 @@ public class Assembly extends OptionsBuilder {
     public AssemblyResponse save(boolean isResumable)
             throws RequestException, LocalOperationException {
         Request request = new Request(getClient());
-        options.put("steps", steps.toMap());
+     		if(!steps.toMap().isEmpty) {
+					options.put("steps", steps.toMap());
+				}
 
         AssemblyResponse response;
         // only do tus uploads if files will be uploaded

--- a/src/main/java/com/transloadit/sdk/Assembly.java
+++ b/src/main/java/com/transloadit/sdk/Assembly.java
@@ -187,7 +187,7 @@ public class Assembly extends OptionsBuilder {
     public AssemblyResponse save(boolean isResumable)
             throws RequestException, LocalOperationException {
         Request request = new Request(getClient());
-     		if(!steps.toMap().isEmpty) {
+     		if(!steps.toMap().isEmpty()) {
 					options.put("steps", steps.toMap());
 				}
 

--- a/src/main/java/com/transloadit/sdk/Assembly.java
+++ b/src/main/java/com/transloadit/sdk/Assembly.java
@@ -187,9 +187,9 @@ public class Assembly extends OptionsBuilder {
     public AssemblyResponse save(boolean isResumable)
             throws RequestException, LocalOperationException {
         Request request = new Request(getClient());
-     		if(!steps.toMap().isEmpty()) {
-					options.put("steps", steps.toMap());
-				}
+        if(!steps.toMap().isEmpty()) {
+            options.put("steps", steps.toMap());
+        }
 
         AssemblyResponse response;
         // only do tus uploads if files will be uploaded

--- a/src/main/resources/version.properties
+++ b/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-versionNumber='0.1.5'
+versionNumber='0.1.6'

--- a/src/test/java/com/transloadit/sdk/RequestTest.java
+++ b/src/test/java/com/transloadit/sdk/RequestTest.java
@@ -33,7 +33,7 @@ public class RequestTest extends MockHttpService {
         mockServerClient.verify(HttpRequest.request()
                 .withPath("/foo")
                 .withMethod("GET")
-                .withHeader("Transloadit-Client", "java-sdk:0.1.5"));
+                .withHeader("Transloadit-Client", "java-sdk:0.1.6"));
 
     }
 


### PR DESCRIPTION
**Commit Message:**
- Fix passing empty steps objects.
- Bump version 0.1.5 -> 0.1.6 in a bunch of places.

Fixes #35 