### PR TITLE
Socket updates

### DIFF
--- a/examples/src/main/java/com/transloadit/examples/ImageResizer.java
+++ b/examples/src/main/java/com/transloadit/examples/ImageResizer.java
@@ -50,6 +50,28 @@ public final class ImageResizer {
             public void onError(Exception error) {
                 error.printStackTrace();
             }
+
+            @Override
+            public void onMetadataExtracted() {
+                System.out.println("Metadata Extracted");
+            }
+
+            @Override
+            public void onAssemblyUploadFinished() {
+                System.out.println("Assembly Upload complete, Executing ...");
+
+            }
+
+            @Override
+            public void onFileUploadFinished(String fileName) {
+                System.out.println("File uploaded: " + fileName);
+            }
+
+            @Override
+            public void onAssemblyResultFinished(AssemblyResponse assemblyResponse) {
+
+            }
+
         });
 
         try {

--- a/examples/src/main/java/com/transloadit/examples/ImageResizer.java
+++ b/examples/src/main/java/com/transloadit/examples/ImageResizer.java
@@ -68,7 +68,7 @@ public final class ImageResizer {
             }
 
             @Override
-            public void onAssemblyResultFinished(AssemblyResponse assemblyResponse) {
+            public void onAssemblyResultFinished(String stepName, JSONObject result) {
 
             }
 

--- a/examples/src/main/java/com/transloadit/examples/ImageResizer.java
+++ b/examples/src/main/java/com/transloadit/examples/ImageResizer.java
@@ -63,7 +63,7 @@ public final class ImageResizer {
             }
 
             @Override
-            public void onFileUploadFinished(String fileName) {
+            public void onFileUploadFinished(String fileName, JSONObject uploadInformation) {
                 System.out.println("File uploaded: " + fileName);
             }
 

--- a/examples/src/main/java/com/transloadit/examples/MultiStepProcessing.java
+++ b/examples/src/main/java/com/transloadit/examples/MultiStepProcessing.java
@@ -121,8 +121,9 @@ public final class MultiStepProcessing {
 
             @Override
             public void onAssemblyResultFinished(String stepName, JSONObject result) {
-                System.out.println("\n ---- Step Result for Step: " + stepName + "  ---- ");
-                System.out.println("File: " + result.getString("basename") + "." + result.getString("ext"));
+                System.out.println("\n ---- Step Result for Step: ---- ");
+                System.out.println("StepName: " + stepName + "\nFile: " + result.getString("basename") + "."
+                        + result.getString("ext"));
                 System.out.println("Downlaodlink: " + result.getString("ssl_url") + "\n");
             }
 

--- a/examples/src/main/java/com/transloadit/examples/MultiStepProcessing.java
+++ b/examples/src/main/java/com/transloadit/examples/MultiStepProcessing.java
@@ -36,10 +36,11 @@ public final class MultiStepProcessing {
 
         // Step1 Reduce File's Bitrates
         Map<String, Object> step1 = new HashMap<>();
-        step1.put("preset", "mp3");
+        step1.put("preset", "opus");
         step1.put("bitrate", 128000);
 
         assembly.addStep("encode", "/audio/encode", step1);
+
 
         // Step2 Concatenation
             /* Building "use" parameter as JSONObject
@@ -48,26 +49,28 @@ public final class MultiStepProcessing {
                 -   as = audio_<number> defines oder of Concatenation
                 => Needs to be stored under key "steps" as it defines every substep
              */
+
         JSONObject outerJsonObject = new JSONObject();
         outerJsonObject.append(
                 "steps",
                 new JSONObject()
                         .put("name", "encode")
                         .put("fields", "file_1")
-                        .put("as", "audio_1"));
+                        .put("as", "audio_2"));  // invert order of files in the concat for demonstration purpose
 
         outerJsonObject.append(
                 "steps",
                 new JSONObject()
                         .put("name", "encode")
                         .put("fields", "file_2")
-                        .put("as", "audio_2"));
+                        .put("as", "audio_1"));
 
         Map<String, Object> step2 = new HashMap<>();
         step2.put("preset", "mp3");
         step2.put("use", outerJsonObject);
 
         assembly.addStep("concat", "/audio/concat", step2);
+
 
         // Step 3 Waveform
         Map<String, Object> step3 = new HashMap<>();
@@ -83,9 +86,7 @@ public final class MultiStepProcessing {
         assembly.setAssemblyListener(new AssemblyListener() {
             @Override
             public void onAssemblyFinished(AssemblyResponse response) {
-                JSONArray waveformStatus = response.getStepResult("waveform");
-                System.out.println("Result of Operation:");
-                printStatus(waveformStatus);
+                System.out.println("Assembly finished");
             }
 
             public void printStatus(JSONArray status) {
@@ -119,8 +120,13 @@ public final class MultiStepProcessing {
             }
 
             @Override
-            public void onAssemblyResultFinished(AssemblyResponse assemblyResponse) {
+            public void onAssemblyResultFinished(String stepName, JSONObject result) {
+                System.out.println("\n ---- Step Result for Step: " + stepName + "  ---- ");
+                System.out.println("File: " + result.getString("basename") + "." + result.getString("ext"));
+                System.out.println("Downlaodlink: " + result.getString("ssl_url") + "\n");
             }
+
+
         });
 
 

--- a/examples/src/main/java/com/transloadit/examples/MultiStepProcessing.java
+++ b/examples/src/main/java/com/transloadit/examples/MultiStepProcessing.java
@@ -102,7 +102,28 @@ public final class MultiStepProcessing {
                 System.out.println("Error");
                 error.printStackTrace();
             }
+
+            @Override
+            public void onMetadataExtracted() {
+                System.out.println("Metadata extracted");
+            }
+
+            @Override
+            public void onAssemblyUploadFinished() {
+                System.out.println("Assembly Upload complete. Executing ...");
+            }
+
+            @Override
+            public void onFileUploadFinished(String fileName) {
+                System.out.println("File uploaded: " + fileName);
+            }
+
+            @Override
+            public void onAssemblyResultFinished(AssemblyResponse assemblyResponse) {
+            }
         });
+
+
 
         try {
             System.out.println("Processing... ");

--- a/examples/src/main/java/com/transloadit/examples/MultiStepProcessing.java
+++ b/examples/src/main/java/com/transloadit/examples/MultiStepProcessing.java
@@ -115,7 +115,7 @@ public final class MultiStepProcessing {
             }
 
             @Override
-            public void onFileUploadFinished(String fileName) {
+            public void onFileUploadFinished(String fileName, JSONObject uploadInformation) {
                 System.out.println("File uploaded: " + fileName);
             }
 

--- a/src/main/java/com/transloadit/sdk/Assembly.java
+++ b/src/main/java/com/transloadit/sdk/Assembly.java
@@ -493,9 +493,43 @@ public class Assembly extends OptionsBuilder {
             }
         };
 
+        Emitter.Listener onMetadataExtracted = args -> {
+            getAssemblyListener().onMetadataExtracted();
+        };
+
+
+        Emitter.Listener onAssemblyResultFinished = args -> {
+            try {
+                AssemblyResponse resp = transloadit.getAssemblyByUrl(assemblyUrl);
+            } catch (RequestException e) {
+                e.printStackTrace();
+            } catch (LocalOperationException e) {
+                e.printStackTrace();
+            }
+        };
+
+        /**
+         * Hands over Filename of recently uploaded file to the callback in the {@link Assembly#assemblyListener}
+         */                                                                    
+        Emitter.Listener onUploadFinished = args -> {
+                   String name = ((JSONObject) args[0]).getString("name");
+                   getAssemblyListener().onFileUploadFinished(name);
+        };
+
+        /**
+         * Triggers callback in the {@link Assembly#assemblyListener} if the Assembly instructions have been uploaded.
+         */
+        Emitter.Listener onAssemblyUploadFinished = args -> {
+                getAssemblyListener().onAssemblyUploadFinished();
+        };
+
         socket
                 .on(Socket.EVENT_CONNECT, onConnect)
                 .on("assembly_finished", onFinished)
+                .on("assembly_uploading_finished", onAssemblyUploadFinished)
+                .on("assembly_upload_finished", onUploadFinished)
+                .on("assembly_upload_meta_data_extracted", onMetadataExtracted)
+                .on("assembly_result_finished", onAssemblyResultFinished)
                 .on("assembly_error", onFinished)
                 .on(Socket.EVENT_ERROR, onError);
         socket.connect();

--- a/src/main/java/com/transloadit/sdk/Assembly.java
+++ b/src/main/java/com/transloadit/sdk/Assembly.java
@@ -500,7 +500,7 @@ public class Assembly extends OptionsBuilder {
 
         Emitter.Listener onAssemblyResultFinished = args -> {
             try {
-                AssemblyResponse resp = transloadit.getAssemblyByUrl(assemblyUrl);
+                getAssemblyListener().onAssemblyResultFinished(transloadit.getAssemblyByUrl(assemblyUrl));
             } catch (RequestException e) {
                 e.printStackTrace();
             } catch (LocalOperationException e) {
@@ -509,7 +509,7 @@ public class Assembly extends OptionsBuilder {
         };
 
         //Hands over Filename of recently uploaded file to the callback in the AssemblyListener
-        Emitter.Listener onUploadFinished = args -> {
+        Emitter.Listener onFileUploadFinished = args -> {
                    String name = ((JSONObject) args[0]).getString("name");
                    getAssemblyListener().onFileUploadFinished(name);
         };
@@ -523,7 +523,7 @@ public class Assembly extends OptionsBuilder {
                 .on(Socket.EVENT_CONNECT, onConnect)
                 .on("assembly_finished", onFinished)
                 .on("assembly_uploading_finished", onAssemblyUploadFinished)
-                .on("assembly_upload_finished", onUploadFinished)
+                .on("assembly_upload_finished", onFileUploadFinished)
                 .on("assembly_upload_meta_data_extracted", onMetadataExtracted)
                 .on("assembly_result_finished", onAssemblyResultFinished)
                 .on("assembly_error", onFinished)

--- a/src/main/java/com/transloadit/sdk/Assembly.java
+++ b/src/main/java/com/transloadit/sdk/Assembly.java
@@ -499,13 +499,9 @@ public class Assembly extends OptionsBuilder {
 
 
         Emitter.Listener onAssemblyResultFinished = args -> {
-            try {
-                getAssemblyListener().onAssemblyResultFinished(transloadit.getAssemblyByUrl(assemblyUrl));
-            } catch (RequestException e) {
-                e.printStackTrace();
-            } catch (LocalOperationException e) {
-                e.printStackTrace();
-            }
+            String stepName = (String) args[0];
+            JSONObject result = (JSONObject) args[1];
+            getAssemblyListener().onAssemblyResultFinished(stepName, result);
         };
 
         //Hands over Filename of recently uploaded file to the callback in the AssemblyListener

--- a/src/main/java/com/transloadit/sdk/Assembly.java
+++ b/src/main/java/com/transloadit/sdk/Assembly.java
@@ -508,17 +508,13 @@ public class Assembly extends OptionsBuilder {
             }
         };
 
-        /**
-         * Hands over Filename of recently uploaded file to the callback in the {@link Assembly#assemblyListener}
-         */                                                                    
+        //Hands over Filename of recently uploaded file to the callback in the AssemblyListener
         Emitter.Listener onUploadFinished = args -> {
                    String name = ((JSONObject) args[0]).getString("name");
                    getAssemblyListener().onFileUploadFinished(name);
         };
 
-        /**
-         * Triggers callback in the {@link Assembly#assemblyListener} if the Assembly instructions have been uploaded.
-         */
+        // Triggers callback in the {@link Assembly#assemblyListener} if the Assembly instructions have been uploaded.
         Emitter.Listener onAssemblyUploadFinished = args -> {
                 getAssemblyListener().onAssemblyUploadFinished();
         };

--- a/src/main/java/com/transloadit/sdk/Assembly.java
+++ b/src/main/java/com/transloadit/sdk/Assembly.java
@@ -507,7 +507,8 @@ public class Assembly extends OptionsBuilder {
         //Hands over Filename of recently uploaded file to the callback in the AssemblyListener
         Emitter.Listener onFileUploadFinished = args -> {
                    String name = ((JSONObject) args[0]).getString("name");
-                   getAssemblyListener().onFileUploadFinished(name);
+                   JSONObject uploadInformation = (JSONObject) args[0];
+                   getAssemblyListener().onFileUploadFinished(name, uploadInformation);
         };
 
         // Triggers callback in the {@link Assembly#assemblyListener} if the Assembly instructions have been uploaded.

--- a/src/main/java/com/transloadit/sdk/AssemblyListener.java
+++ b/src/main/java/com/transloadit/sdk/AssemblyListener.java
@@ -37,8 +37,9 @@ public interface AssemblyListener {
     /**
      * Callback to be executed if one of the Assembly's files has been uploaded.
      * @param fileName Name of the file, which has been successfully uploaded.
+     * @param uploadInformation {@link JSONObject}, which holds information about the uploaded file as Key-Value pairs.
      */
-    void onFileUploadFinished(String fileName);
+    void onFileUploadFinished(String fileName, JSONObject uploadInformation);
 
     /**
      * Callback to be executed if there is an Assembly result.

--- a/src/main/java/com/transloadit/sdk/AssemblyListener.java
+++ b/src/main/java/com/transloadit/sdk/AssemblyListener.java
@@ -22,4 +22,18 @@ public interface AssemblyListener {
      * @param error {@link Exception} the error thrown during the socket connection.
      */
     void onError(Exception error);
+
+    /**
+     * Callback to be exectued if the Assembly's files metadata has been extracted.
+     */
+    void onMetadataExtracted();
+
+    /**
+     * Callback to be executed if the Assembly's files have been uploaded
+     */
+    void onAssemblyUploadFinished();
+
+    void onFileUploadFinished(String fileName);
+
+
 }

--- a/src/main/java/com/transloadit/sdk/AssemblyListener.java
+++ b/src/main/java/com/transloadit/sdk/AssemblyListener.java
@@ -29,7 +29,7 @@ public interface AssemblyListener {
     void onMetadataExtracted();
 
     /**
-     * Callback to be executed if the Assembly's files have been uploaded.
+     * Callback to be executed if the Assembly's files have been uploaded and the Assembly execution starts.
      */
     void onAssemblyUploadFinished();
 
@@ -38,6 +38,12 @@ public interface AssemblyListener {
      * @param fileName Name of the file, which has been successfully uploaded.
      */
     void onFileUploadFinished(String fileName);
+
+    /**
+     * Callback to be executed if there is an Assembly result.
+     * @param assemblyResponse {@link AssemblyResponse}, which contains status Information about the result.
+     */
+    void onAssemblyResultFinished(AssemblyResponse assemblyResponse);
 
 
 }

--- a/src/main/java/com/transloadit/sdk/AssemblyListener.java
+++ b/src/main/java/com/transloadit/sdk/AssemblyListener.java
@@ -1,6 +1,7 @@
 package com.transloadit.sdk;
 
 import com.transloadit.sdk.response.AssemblyResponse;
+import org.json.JSONObject;
 
 /**
  * Interface for a Listener, which tracks the progress in Assembly execution.
@@ -41,9 +42,10 @@ public interface AssemblyListener {
 
     /**
      * Callback to be executed if there is an Assembly result.
-     * @param assemblyResponse {@link AssemblyResponse}, which contains status Information about the result.
+     * @param stepName name of the step, the result is part of
+     * @param result {@link JSONObject} which holds information about the result as Key-Value pairs.
      */
-    void onAssemblyResultFinished(AssemblyResponse assemblyResponse);
+    void onAssemblyResultFinished(String stepName, JSONObject result);
 
 
 }

--- a/src/main/java/com/transloadit/sdk/AssemblyListener.java
+++ b/src/main/java/com/transloadit/sdk/AssemblyListener.java
@@ -29,10 +29,14 @@ public interface AssemblyListener {
     void onMetadataExtracted();
 
     /**
-     * Callback to be executed if the Assembly's files have been uploaded
+     * Callback to be executed if the Assembly's files have been uploaded.
      */
     void onAssemblyUploadFinished();
 
+    /**
+     * Callback to be executed if one of the Assembly's files has been uploaded.
+     * @param fileName Name of the file, which has been successfully uploaded.
+     */
     void onFileUploadFinished(String fileName);
 
 

--- a/src/test/java/com/transloadit/sdk/AssemblyTest.java
+++ b/src/test/java/com/transloadit/sdk/AssemblyTest.java
@@ -252,6 +252,11 @@ public class AssemblyTest extends MockHttpService {
             public void onFileUploadFinished(String fileName) {
 
             }
+
+            @Override
+            public void onAssemblyResultFinished(AssemblyResponse assemblyResponse) {
+
+            }
         });
 
         mockServerClient.when(HttpRequest.request()

--- a/src/test/java/com/transloadit/sdk/AssemblyTest.java
+++ b/src/test/java/com/transloadit/sdk/AssemblyTest.java
@@ -237,6 +237,21 @@ public class AssemblyTest extends MockHttpService {
             public void onError(Exception error) {
                 System.err.println("No Mockserver Response");
             }
+
+            @Override
+            public void onMetadataExtracted() {
+
+            }
+
+            @Override
+            public void onAssemblyUploadFinished() {
+
+            }
+
+            @Override
+            public void onFileUploadFinished(String fileName) {
+
+            }
         });
 
         mockServerClient.when(HttpRequest.request()

--- a/src/test/java/com/transloadit/sdk/AssemblyTest.java
+++ b/src/test/java/com/transloadit/sdk/AssemblyTest.java
@@ -250,7 +250,7 @@ public class AssemblyTest extends MockHttpService {
             }
 
             @Override
-            public void onFileUploadFinished(String fileName) {
+            public void onFileUploadFinished(String fileName, JSONObject uploadInformation) {
 
             }
 

--- a/src/test/java/com/transloadit/sdk/AssemblyTest.java
+++ b/src/test/java/com/transloadit/sdk/AssemblyTest.java
@@ -3,6 +3,7 @@ package com.transloadit.sdk;
 import com.transloadit.sdk.exceptions.LocalOperationException;
 import com.transloadit.sdk.exceptions.RequestException;
 import com.transloadit.sdk.response.AssemblyResponse;
+import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -254,9 +255,11 @@ public class AssemblyTest extends MockHttpService {
             }
 
             @Override
-            public void onAssemblyResultFinished(AssemblyResponse assemblyResponse) {
+            public void onAssemblyResultFinished(String stepName, JSONObject result) {
+
 
             }
+
         });
 
         mockServerClient.when(HttpRequest.request()


### PR DESCRIPTION
Implemented the basic needs of  Issue #23 .
This means new Interface methods in the Assembly listener and new EmitterListeners to listen on socket events.
In the course of this, I had to adjust the examples and a Unit Test in order to implement the AssemblyListener Interface.

Current Problems:
It is not possible to retrieve the results of single steps if they are linked with each other (No Interim results). The EventListener for this only gets triggered if there is an end result of the whole assembly. It may be a wanted behavior but let's double-check.
It works fine for separate steps, though. 
@Acconut maybe we should have a brief talk about this. I think it's a notification thing from the server-side.

closes #23 