### PR TITLE
New way to get assembly ids

### DIFF
--- a/examples/src/main/java/com/transloadit/examples/ImageResizer.java
+++ b/examples/src/main/java/com/transloadit/examples/ImageResizer.java
@@ -63,12 +63,12 @@ public final class ImageResizer {
             }
 
             @Override
-            public void onFileUploadFinished(String fileName, JSONObject uploadInformation) {
+            public void onFileUploadFinished(String fileName, HashMap uploadInformation) {
                 System.out.println("File uploaded: " + fileName);
             }
 
             @Override
-            public void onAssemblyResultFinished(String stepName, JSONObject result) {
+            public void onAssemblyResultFinished(String stepName, HashMap result) {
 
             }
 

--- a/examples/src/main/java/com/transloadit/examples/KotlinExample.kt
+++ b/examples/src/main/java/com/transloadit/examples/KotlinExample.kt
@@ -73,14 +73,14 @@ class KotlinExample {
                     println("Assembly uploaded, executing ...")
                 }
 
-                override fun onFileUploadFinished(fileName: String?, uploadInformation: JSONObject?) {
+                override fun onFileUploadFinished(fileName: String?, uploadInformation: HashMap<String, Any>?) {
                     println("File " + fileName + "has been uploaded successfully")
                 }
 
-                override fun onAssemblyResultFinished(stepName: String?, result: JSONObject?) {
+                override fun onAssemblyResultFinished(stepName: String?, result: HashMap<String, Any>?) {
                     println("Step Result available: ")
                     println(
-                    """StepName: $stepName File: ${result!!.getString("basename")}.${result.getString("ext")}
+                    """StepName: $stepName File: ${result!!["basename"]}.${result["ext"]}
                     """.trimIndent())
                 }
             }

--- a/examples/src/main/java/com/transloadit/examples/MultiStepProcessing.java
+++ b/examples/src/main/java/com/transloadit/examples/MultiStepProcessing.java
@@ -11,7 +11,6 @@ import org.json.JSONObject;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 
 /**

--- a/examples/src/main/java/com/transloadit/examples/MultiStepProcessing.java
+++ b/examples/src/main/java/com/transloadit/examples/MultiStepProcessing.java
@@ -11,6 +11,7 @@ import org.json.JSONObject;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 
 /**
@@ -115,16 +116,16 @@ public final class MultiStepProcessing {
             }
 
             @Override
-            public void onFileUploadFinished(String fileName, JSONObject uploadInformation) {
+            public void onFileUploadFinished(String fileName, HashMap uploadInformation) {
                 System.out.println("File uploaded: " + fileName);
             }
 
             @Override
-            public void onAssemblyResultFinished(String stepName, JSONObject result) {
+            public void onAssemblyResultFinished(String stepName, HashMap result) {
                 System.out.println("\n ---- Step Result for Step: ---- ");
-                System.out.println("StepName: " + stepName + "\nFile: " + result.getString("basename") + "."
-                        + result.getString("ext"));
-                System.out.println("Downlaodlink: " + result.getString("ssl_url") + "\n");
+                System.out.println("StepName: " + stepName + "\nFile: " + result.get("basename") + "."
+                        + result.get("ext"));
+                System.out.println("Downlaodlink: " + result.get("ssl_url") + "\n");
             }
 
 
@@ -134,7 +135,8 @@ public final class MultiStepProcessing {
 
         try {
             System.out.println("Processing... ");
-            assembly.save();
+            System.out.println("Assembly ID: " + assembly.getAssemblyID());
+            assembly.save(true);
          } catch (LocalOperationException | RequestException e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/transloadit/sdk/Assembly.java
+++ b/src/main/java/com/transloadit/sdk/Assembly.java
@@ -33,6 +33,7 @@ import java.util.Map;
  */
 public class Assembly extends OptionsBuilder {
     private TusURLStore tusURLStore;
+    private String assemblyId;
 
     protected Map<String, File> files;
     protected Map<String, InputStream> fileStreams;
@@ -223,7 +224,7 @@ public class Assembly extends OptionsBuilder {
             tusOptions.put("tus_num_expected_upload_files", Integer.toString(getFilesCount()));
 
             response = new AssemblyResponse(
-                    request.post("/assemblies", options, tusOptions, null, null), true);
+                    request.post(obtainRequestUrlSuffix(), options, tusOptions, null, null), true);
 
             // check if the assembly returned an error
             if (response.hasError()) {
@@ -242,7 +243,7 @@ public class Assembly extends OptionsBuilder {
                 throw new RequestException(e);
             }
         } else {
-            response = new AssemblyResponse(request.post("/assemblies", options, null, files, fileStreams));
+            response = new AssemblyResponse(request.post(obtainRequestUrlSuffix(), options, null, files, fileStreams));
             if (shouldWaitWithSocket() && !response.isFinished()) {
                 listenToSocket(response);
             }
@@ -549,5 +550,31 @@ public class Assembly extends OptionsBuilder {
         }
 
         return response;
+    }
+
+    /**
+     * Obtains the URL suffix for requests
+     * @return URL for requests
+     */
+    protected String obtainRequestUrlSuffix() {
+        if (assemblyId == null) {
+            return "/assemblies";
+        } else {
+            return "/assemblies/"  + assemblyId;
+        }
+    }
+
+    /**
+     * @param assemblyId
+     */
+    public void setAssemblyId(String assemblyId) {
+        // undocumented debug option
+        // not safe for production use
+        if (assemblyId.matches("[a-zA-Z0-9]{32}")) { //Check ID Format
+            this.assemblyId = assemblyId.toLowerCase();
+        } else {
+            System.err.println("Provided Assembly ID doesn't match expectations");
+            assemblyId = null;
+        }
     }
 }

--- a/src/main/java/com/transloadit/sdk/Assembly.java
+++ b/src/main/java/com/transloadit/sdk/Assembly.java
@@ -586,7 +586,8 @@ public class Assembly extends OptionsBuilder {
     }
 
     /**
-     * Returns the assembly ID generated on client side to allow early logging.
+     * Returns the assembly ID generated on client side to allow early logging. Be aware the Assembly ID will change if
+     * you use the {@link Assembly#wipeAssemblyID()} method.
      * @return {@link String}AssemblyID
      */
     public String getAssemblyID() {
@@ -603,8 +604,10 @@ public class Assembly extends OptionsBuilder {
 
     /**
      * Wipes the client side generated Assembly-ID. As a result, the assembly id is assigned by the API after upload.
+     * In this case you cannot obtain the Assembly ID before receiving a server response. As a result every Assembly ID
+     * obtained by {@link Assembly#getAssemblyID()} would be invalid.
      */
-    public void wipeAssemblyID() {
+    protected void wipeAssemblyID() {
         this.assemblyId = "";
     }
 

--- a/src/main/java/com/transloadit/sdk/AssemblyListener.java
+++ b/src/main/java/com/transloadit/sdk/AssemblyListener.java
@@ -1,7 +1,7 @@
 package com.transloadit.sdk;
 
 import com.transloadit.sdk.response.AssemblyResponse;
-import org.json.JSONObject;
+
 
 import java.util.HashMap;
 
@@ -41,14 +41,14 @@ public interface AssemblyListener {
      * @param fileName Name of the file, which has been successfully uploaded.
      * @param uploadInformation {@link HashMap}, which holds information about the uploaded file as Key-Value pairs.
      */
-    void onFileUploadFinished(String fileName, HashMap<String,Object>  uploadInformation);
+    void onFileUploadFinished(String fileName, HashMap<String, Object>  uploadInformation);
 
     /**
      * Callback to be executed if there is an Assembly result.
      * @param stepName name of the step, the result is part of
      * @param result {@link HashMap} which holds information about the result as Key-Value pairs.
      */
-    void onAssemblyResultFinished(String stepName, HashMap<String,Object> result);
+    void onAssemblyResultFinished(String stepName, HashMap<String, Object> result);
 
 
 }

--- a/src/main/java/com/transloadit/sdk/AssemblyListener.java
+++ b/src/main/java/com/transloadit/sdk/AssemblyListener.java
@@ -3,6 +3,8 @@ package com.transloadit.sdk;
 import com.transloadit.sdk.response.AssemblyResponse;
 import org.json.JSONObject;
 
+import java.util.HashMap;
+
 /**
  * Interface for a Listener, which tracks the progress in Assembly execution.
  */
@@ -37,16 +39,16 @@ public interface AssemblyListener {
     /**
      * Callback to be executed if one of the Assembly's files has been uploaded.
      * @param fileName Name of the file, which has been successfully uploaded.
-     * @param uploadInformation {@link JSONObject}, which holds information about the uploaded file as Key-Value pairs.
+     * @param uploadInformation {@link HashMap}, which holds information about the uploaded file as Key-Value pairs.
      */
-    void onFileUploadFinished(String fileName, JSONObject uploadInformation);
+    void onFileUploadFinished(String fileName, HashMap<String,Object>  uploadInformation);
 
     /**
      * Callback to be executed if there is an Assembly result.
      * @param stepName name of the step, the result is part of
-     * @param result {@link JSONObject} which holds information about the result as Key-Value pairs.
+     * @param result {@link HashMap} which holds information about the result as Key-Value pairs.
      */
-    void onAssemblyResultFinished(String stepName, JSONObject result);
+    void onAssemblyResultFinished(String stepName, HashMap<String,Object> result);
 
 
 }

--- a/src/test/java/com/transloadit/sdk/AssemblyTest.java
+++ b/src/test/java/com/transloadit/sdk/AssemblyTest.java
@@ -359,4 +359,33 @@ public class AssemblyTest extends MockHttpService {
         // check if assembly was successfully retried
         assertEquals(savedAssembly.json().get("ok"), "ASSEMBLY_EXECUTING");
     }
+
+    /**
+     * Tests URL creation in case of user definition.
+     */
+    @Test
+    public void obtainRequestUrlSuffix() {
+        assertEquals(assembly.obtainRequestUrlSuffix(), "/assemblies");
+        String uuid = "6859bd25474d40b8bf7a294cfce4aba5";
+        assembly.setAssemblyId(uuid);
+        assertEquals(assembly.obtainRequestUrlSuffix(), "/assemblies/" + uuid);
+    }
+
+    /**
+     * Tests the integrity check of AssemblyID setting.
+     */
+    @Test
+    public void setAssemblyId() {
+        String uuid = "6859bd25474d40b8bf7a294cfce4aba5";
+        String uuidShort = "6859bd25474d";
+        String uuidLong = "6859bd25474d40b8bf7a294cfce4aba56859bd25474d40b8bf7a294cfce4aba5";
+        String uuidWrongChar = "6859bd25474d40b8bf-a294cfce4aba5";
+        assembly.setAssemblyId(uuidShort);
+        assertEquals(assembly.obtainRequestUrlSuffix(), "/assemblies");
+        assembly.setAssemblyId(uuidWrongChar);
+        assertEquals(assembly.obtainRequestUrlSuffix(), "/assemblies");
+        assembly.setAssemblyId(uuid);
+        assertEquals(assembly.obtainRequestUrlSuffix(), "/assemblies/" + uuid);
+    }
+
 }

--- a/src/test/java/com/transloadit/sdk/AssemblyTest.java
+++ b/src/test/java/com/transloadit/sdk/AssemblyTest.java
@@ -3,7 +3,7 @@ package com.transloadit.sdk;
 import com.transloadit.sdk.exceptions.LocalOperationException;
 import com.transloadit.sdk.exceptions.RequestException;
 import com.transloadit.sdk.response.AssemblyResponse;
-import org.json.JSONObject;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -18,6 +18,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
@@ -54,7 +55,7 @@ public class AssemblyTest extends MockHttpService {
      */
     @Before
     public void setUp() throws Exception {
-        assembly = new Assembly(transloadit);
+        assembly = newAssemblyWithoutID();
         assemblyFinished = false;
         mockServerClient.reset();
     }
@@ -250,12 +251,12 @@ public class AssemblyTest extends MockHttpService {
             }
 
             @Override
-            public void onFileUploadFinished(String fileName, JSONObject uploadInformation) {
+            public void onFileUploadFinished(String fileName, HashMap uploadInformation) {
 
             }
 
             @Override
-            public void onAssemblyResultFinished(String stepName, JSONObject result) {
+            public void onAssemblyResultFinished(String stepName, HashMap result) {
 
 
             }
@@ -361,31 +362,55 @@ public class AssemblyTest extends MockHttpService {
     }
 
     /**
-     * Tests URL creation in case of user definition.
+     * Tests the integrity check of {@link Assembly#setAssemblyId(String)}.
      */
     @Test
-    public void obtainRequestUrlSuffix() {
-        assertEquals(assembly.obtainRequestUrlSuffix(), "/assemblies");
-        String uuid = "6859bd25474d40b8bf7a294cfce4aba5";
-        assembly.setAssemblyId(uuid);
-        assertEquals(assembly.obtainRequestUrlSuffix(), "/assemblies/" + uuid);
-    }
-
-    /**
-     * Tests the integrity check of AssemblyID setting.
-     */
-    @Test
-    public void setAssemblyId() {
+    public void setAssemblyId() throws LocalOperationException {
         String uuid = "6859bd25474d40b8bf7a294cfce4aba5";
         String uuidShort = "6859bd25474d";
         String uuidLong = "6859bd25474d40b8bf7a294cfce4aba56859bd25474d40b8bf7a294cfce4aba5";
         String uuidWrongChar = "6859bd25474d40b8bf-a294cfce4aba5";
-        assembly.setAssemblyId(uuidShort);
-        assertEquals(assembly.obtainRequestUrlSuffix(), "/assemblies");
-        assembly.setAssemblyId(uuidWrongChar);
-        assertEquals(assembly.obtainRequestUrlSuffix(), "/assemblies");
+        Assert.assertThrows(LocalOperationException.class, () ->  {
+            assembly.setAssemblyId(uuidShort); });
+        Assert.assertThrows(LocalOperationException.class, () ->  {
+            assembly.setAssemblyId(uuidWrongChar); });
+        Assert.assertThrows(LocalOperationException.class, () ->  {
+            assembly.setAssemblyId(uuidLong); });
         assembly.setAssemblyId(uuid);
-        assertEquals(assembly.obtainRequestUrlSuffix(), "/assemblies/" + uuid);
+        assertEquals(assembly.getAssemblyID(), uuid);
     }
 
+    /**
+     * Tests the functionality of {@link Assembly#getAssemblyID()}.
+     */
+    @Test
+    public void getAssemblyId() throws LocalOperationException {
+        assembly.setAssemblyId("68fffff5474d40b8bf7a294cfce4aba5");
+        assertEquals("68fffff5474d40b8bf7a294cfce4aba5", assembly.getAssemblyID());
+    }
+
+    /**
+     * Tests the functionality of {@link Assembly#generateAssemblyID()}.
+     * Test succeeds if a certain pattern is generated and every run generates a different String.
+     */
+    @Test
+    public void generateAssemblyID() throws LocalOperationException {
+        String assemblyID1 = assembly.generateAssemblyID();
+        String assemblyID2 = assembly.generateAssemblyID();
+
+        assertTrue(assemblyID1.matches("[a-f0-9]{32}"));
+        assertTrue(assemblyID2.matches("[a-f0-9]{32}"));
+        assertFalse(assemblyID1.equals(assemblyID2));
+    }
+
+    /**
+     * Tests whether the upload Url suffixes are generated correctly.
+     */
+    @Test
+    public void obtainUploadUrlSuffix() throws LocalOperationException {
+        assertEquals("/assemblies", assembly.obtainUploadUrlSuffix());
+        String assemblyID = assembly.generateAssemblyID();
+        assembly.setAssemblyId(assemblyID);
+        assertEquals("/assemblies/" + assemblyID, assembly.obtainUploadUrlSuffix());
+    }
 }

--- a/src/test/java/com/transloadit/sdk/MockHttpService.java
+++ b/src/test/java/com/transloadit/sdk/MockHttpService.java
@@ -16,7 +16,7 @@ public class MockHttpService {
     //CHECKSTYLE:ON
 
     /**
-     * Provides an Assembly object without Assembly ID
+     * Provides an Assembly object without Assembly ID.
      * @return Assembly object without Assembly ID
      */
     protected Assembly newAssemblyWithoutID() {

--- a/src/test/java/com/transloadit/sdk/MockHttpService.java
+++ b/src/test/java/com/transloadit/sdk/MockHttpService.java
@@ -14,6 +14,16 @@ public class MockHttpService {
     protected final Transloadit transloadit = new Transloadit("KEY", "SECRET",
             "http://localhost:" + PORT);
     //CHECKSTYLE:ON
+
+    /**
+     * Provides an Assembly object without Assembly ID
+     * @return Assembly object without Assembly ID
+     */
+    protected Assembly newAssemblyWithoutID() {
+        Assembly assembly = new Assembly(transloadit);
+        assembly.wipeAssemblyID();
+        return assembly;
+    }
     /**
      * Loads test resources from src/test/resources/__files/ with the specified name and provides them as a JSON String.
      * @param name name of test resource.

--- a/src/test/java/com/transloadit/sdk/MockTusAssembly.java
+++ b/src/test/java/com/transloadit/sdk/MockTusAssembly.java
@@ -28,6 +28,7 @@ public class MockTusAssembly extends Assembly {
     public MockTusAssembly(Transloadit transloadit) {
         super(transloadit);
         emitted = new HashMap<String, Object>();
+        assemblyId = "";
     }
 
     @Override

--- a/src/test/java/com/transloadit/sdk/async/MockAsyncAssembly.java
+++ b/src/test/java/com/transloadit/sdk/async/MockAsyncAssembly.java
@@ -24,6 +24,7 @@ public class MockAsyncAssembly extends AsyncAssembly {
     public MockAsyncAssembly(Transloadit transloadit, UploadProgressListener listener) {
         super(transloadit, listener);
         tusClient = new MockTusClient();
+        assemblyId = "";
     }
 
     /**
@@ -34,6 +35,7 @@ public class MockAsyncAssembly extends AsyncAssembly {
     public MockAsyncAssembly(Transloadit transloadit, AssemblyProgressListener listener) {
         super(transloadit, listener);
         tusClient = new MockTusClient();
+        assemblyId = "";
     }
 
     /**

--- a/src/test/java/com/transloadit/sdk/async/MockStatusErrorAsyncAssembly.java
+++ b/src/test/java/com/transloadit/sdk/async/MockStatusErrorAsyncAssembly.java
@@ -18,6 +18,7 @@ public class MockStatusErrorAsyncAssembly extends AsyncAssembly {
     public MockStatusErrorAsyncAssembly(Transloadit transloadit, UploadProgressListener listener) {
         super(transloadit, listener);
         tusClient = new MockAsyncAssembly.MockTusClient();
+        assemblyId = "";
     }
 
     /**
@@ -29,6 +30,7 @@ public class MockStatusErrorAsyncAssembly extends AsyncAssembly {
     public MockStatusErrorAsyncAssembly(Transloadit transloadit, AssemblyProgressListener listener) {
         super(transloadit, listener);
         tusClient = new MockAsyncAssembly.MockTusClient();
+        assemblyId = "";
     }
 
     /**

--- a/src/test/java/com/transloadit/sdk/async/MockUploadErrorAsyncAssembly.java
+++ b/src/test/java/com/transloadit/sdk/async/MockUploadErrorAsyncAssembly.java
@@ -22,6 +22,7 @@ public class MockUploadErrorAsyncAssembly extends AsyncAssembly {
     public MockUploadErrorAsyncAssembly(Transloadit transloadit, UploadProgressListener listener) {
         super(transloadit, listener);
         tusClient = new MockTusClient();
+        assemblyId = "";
     }
 
     /**
@@ -32,6 +33,7 @@ public class MockUploadErrorAsyncAssembly extends AsyncAssembly {
     public MockUploadErrorAsyncAssembly(Transloadit transloadit, AssemblyProgressListener listener) {
         super(transloadit, listener);
         tusClient = new MockTusClient();
+        assemblyId = "";
     }
 
     /**

--- a/src/test/java/com/transloadit/sdk/response/AssemblyResponseTest.java
+++ b/src/test/java/com/transloadit/sdk/response/AssemblyResponseTest.java
@@ -1,6 +1,5 @@
 package com.transloadit.sdk.response;
 
-import com.transloadit.sdk.Assembly;
 import com.transloadit.sdk.MockHttpService;
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/com/transloadit/sdk/response/AssemblyResponseTest.java
+++ b/src/test/java/com/transloadit/sdk/response/AssemblyResponseTest.java
@@ -36,7 +36,6 @@ public class AssemblyResponseTest extends MockHttpService {
      */
     private AssemblyResponse response;
 
-
     /**
      * Instantiates a new {@link AssemblyResponse} instance by mocking an Assembly execution and resets the MockServer
      * before each test.
@@ -47,8 +46,7 @@ public class AssemblyResponseTest extends MockHttpService {
         mockServerClient.when(HttpRequest.request()
                 .withPath("/assemblies").withMethod("POST"))
                 .respond(HttpResponse.response().withBody(getJson("assembly.json")));
-
-        response = new Assembly(transloadit).save(false);
+        response = newAssemblyWithoutID().save();
         mockServerClient.reset();
     }
 
@@ -118,7 +116,7 @@ public class AssemblyResponseTest extends MockHttpService {
                                 + "\"assembly_url\":\"foo\",\n"
                                 + "\"assembly_ssl_url\":\"bar\"}"));
 
-        AssemblyResponse abortedResponse = new Assembly(transloadit).save(false);
+        AssemblyResponse abortedResponse = newAssemblyWithoutID().save(false);
 
         assertTrue(abortedResponse.isAborted());
         assertFalse(response.isAborted());
@@ -139,7 +137,7 @@ public class AssemblyResponseTest extends MockHttpService {
                                 + "\"assembly_url\":\"foo\",\n"
                                 + "\"assembly_ssl_url\":\"bar\"}"));
 
-        AssemblyResponse cancelledResponse = new Assembly(transloadit).save(false);
+        AssemblyResponse cancelledResponse = newAssemblyWithoutID().save(false);
 
         assertTrue(cancelledResponse.isCanceled());
         assertFalse(response.isCanceled());
@@ -160,7 +158,7 @@ public class AssemblyResponseTest extends MockHttpService {
                                 + "\"assembly_url\":\"foo\",\n"
                                 + "\"assembly_ssl_url\":\"bar\"}"));
 
-        AssemblyResponse executingResponse = new Assembly(transloadit).save(false);
+        AssemblyResponse executingResponse = newAssemblyWithoutID().save(false);
 
         assertTrue(executingResponse.isExecuting());
         assertFalse(response.isExecuting());
@@ -180,7 +178,8 @@ public class AssemblyResponseTest extends MockHttpService {
                                 + "\"assembly_url\":\"foo\",\n"
                                 + "\"assembly_ssl_url\":\"bar\"}"));
 
-        AssemblyResponse executingResponse = new Assembly(transloadit).save(false);
+
+        AssemblyResponse executingResponse = newAssemblyWithoutID().save(false);
 
         assertFalse(executingResponse.isFinished());
         assertTrue(response.isFinished());

--- a/src/test/java/com/transloadit/sdk/response/ResponseTest.java
+++ b/src/test/java/com/transloadit/sdk/response/ResponseTest.java
@@ -48,7 +48,7 @@ public class ResponseTest extends MockHttpService {
                 .withPath("/assemblies").withMethod("POST"))
                 .respond(HttpResponse.response().withBody(getJson("assembly.json")));
 
-        AssemblyResponse response = new Assembly(transloadit).save(false);
+        AssemblyResponse response = newAssemblyWithoutID().save(false);
         assertEquals(response.json().getString("ok"), "ASSEMBLY_COMPLETED");
     }
 
@@ -62,7 +62,7 @@ public class ResponseTest extends MockHttpService {
                 .withPath("/assemblies").withMethod("POST"))
                 .respond(HttpResponse.response().withBody(getJson("assembly.json")));
 
-        AssemblyResponse response = new Assembly(transloadit).save(false);
+        AssemblyResponse response = newAssemblyWithoutID().save(false);
         assertEquals(response.status(), 200);
     }
 

--- a/src/test/java/com/transloadit/sdk/response/ResponseTest.java
+++ b/src/test/java/com/transloadit/sdk/response/ResponseTest.java
@@ -1,6 +1,5 @@
 package com.transloadit.sdk.response;
 
-import com.transloadit.sdk.Assembly;
 import com.transloadit.sdk.MockHttpService;
 import org.junit.Before;
 import org.junit.Rule;


### PR DESCRIPTION
This PR focuses on Assembly IDs.
It empowers the client to generate its own assembly IDs derived from UUIDv4. They are derived from a PNRG (java.security.SecureRandom), which is expected to be safe enough.
The aim is to have the possibility for Assembly logging before the server has even responded.
The new Assembly#getAssemblyID() method lets the customer retrieve the Assembly-ID for every Assembly right before it has been uploaded.

There is also a debug method that can be used to set custom assembly IDs.


Also removed the JSONObjects from the assembly listener to enable the use of the listener without having the need of the library installed.