### PR TITLE
Socket io upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 0.4.4 / 2022-10-30 ###
+* The Socket-IO plugin has been updated to version 4, which is also used by the API.
+
 ### 0.4.3 / 2022-10-28 ###
 * Includes a vulnerability patch in the used socket-io implementation
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Existing users should take note of the [JCenter shutdown](https://jfrog.com/blog
 **Gradle:**
 
 ```groovy
-implementation 'com.transloadit.sdk:transloadit:0.4.3'
+implementation 'com.transloadit.sdk:transloadit:0.4.4'
 ```
 
 **Maven:**
@@ -29,7 +29,7 @@ implementation 'com.transloadit.sdk:transloadit:0.4.3'
 <dependency>
   <groupId>com.transloadit.sdk</groupId>
   <artifactId>transloadit</artifactId>
-  <version>0.4.3</version>
+  <version>0.4.4</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.json:json:20220924'
     implementation 'commons-codec:commons-codec:1.15'
-    implementation 'io.socket:socket.io-client:1.0.2'
+    implementation 'io.socket:socket.io-client:2.1.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mock-server:mockserver-junit-rule:5.14.0'
     testImplementation 'org.mockito:mockito-core:4.8.0'

--- a/examples/src/main/java/com/transloadit/examples/MultiStepProcessing.java
+++ b/examples/src/main/java/com/transloadit/examples/MultiStepProcessing.java
@@ -134,7 +134,7 @@ public final class MultiStepProcessing {
 
         try {
             System.out.println("Processing... ");
-            System.out.println("Assembly ID: " + assembly.getAssemblyID());
+            System.out.println("Assembly ID: " + assembly.getClientSideGeneratedAssemblyID());
             assembly.save(true);
          } catch (LocalOperationException | RequestException e) {
             e.printStackTrace();

--- a/src/main/resources/java-sdk-version/version.properties
+++ b/src/main/resources/java-sdk-version/version.properties
@@ -1,1 +1,1 @@
-versionNumber='0.4.3'
+versionNumber='0.4.4'

--- a/src/test/java/com/transloadit/sdk/RequestTest.java
+++ b/src/test/java/com/transloadit/sdk/RequestTest.java
@@ -65,7 +65,7 @@ public class RequestTest extends MockHttpService {
         mockServerClient.verify(HttpRequest.request()
                 .withPath("/foo")
                 .withMethod("GET")
-                .withHeader("Transloadit-Client", "java-sdk:0.4.3"));
+                .withHeader("Transloadit-Client", "java-sdk:0.4.4"));
 
     }
 


### PR DESCRIPTION
The Socket-IO plugin has been updated to version 4, which is also used by the API.