### PR TITLE
Update signature authentication

### DIFF
--- a/src/main/java/com/transloadit/sdk/Request.java
+++ b/src/main/java/com/transloadit/sdk/Request.java
@@ -27,7 +27,11 @@ import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
 
 /**
  * Transloadit tailored Http Request class.

--- a/src/main/java/com/transloadit/sdk/Request.java
+++ b/src/main/java/com/transloadit/sdk/Request.java
@@ -350,14 +350,14 @@ public class Request {
      */
     private String getSignature(String message) throws LocalOperationException {
         byte[] kSecret = transloadit.secret.getBytes(Charset.forName("UTF-8"));
-        byte[] rawHmac = hmacSHA1(kSecret, message);
+        byte[] rawHmac = hmacSHA384(kSecret, message);
         byte[] hexBytes = new Hex().encode(rawHmac);
-
-        return new String(hexBytes, Charset.forName("UTF-8"));
+        String signature = "sha384:" + new String(hexBytes, Charset.forName("UTF-8"));
+        return signature;
     }
 
-    private byte[] hmacSHA1(byte[] key, String data) throws LocalOperationException {
-        final String algorithm = "HmacSHA1";
+    private byte[] hmacSHA384(byte[] key, String data) throws LocalOperationException {
+        final String algorithm = "HmacSHA384";
         Mac mac;
 
         try {

--- a/src/test/java/com/transloadit/sdk/RequestTest.java
+++ b/src/test/java/com/transloadit/sdk/RequestTest.java
@@ -180,14 +180,14 @@ public class RequestTest extends MockHttpService {
     }
 
     /**
-     * Test nonce generation
+     * Test secure nonce generation with.
      */
     @Test
     public void getNonce() {
         String cipher = "Blowfish";
         int keyLength = 256;
 
-        String nonce = request.getNonce(cipher,keyLength);
+        String nonce = request.getNonce(cipher, keyLength);
         assertEquals(44, nonce.length());
     }
 
@@ -206,7 +206,4 @@ public class RequestTest extends MockHttpService {
         assertTrue(delta >= timeout);
 
     }
-
-
-
 }

--- a/src/test/java/com/transloadit/sdk/RequestTest.java
+++ b/src/test/java/com/transloadit/sdk/RequestTest.java
@@ -180,6 +180,18 @@ public class RequestTest extends MockHttpService {
     }
 
     /**
+     * Test nonce generation
+     */
+    @Test
+    public void getNonce() {
+        String cipher = "Blowfish";
+        int keyLength = 256;
+
+        String nonce = request.getNonce(cipher,keyLength);
+        assertEquals(44, nonce.length());
+    }
+
+    /**
      * Tests if {@link Request#delayBeforeRetry()} works.
      * @throws LocalOperationException
      */
@@ -198,4 +210,3 @@ public class RequestTest extends MockHttpService {
 
 
 }
-


### PR DESCRIPTION
- Added a nonce in order to prevent a signature reuse error
- Upgraded signature authentication to use HmacSHA384, which is recommended by the API docs.