### PR TITLE
Generated Java SDK contract markers

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -45,6 +45,11 @@ tasks.register('api2DevdockTemplateLifecycle', JavaExec) {
     mainClass = 'com.transloadit.examples.Api2DevdockTemplateLifecycle'
 }
 
+tasks.register('api2DevdockAssemblyLifecycle', JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'com.transloadit.examples.Api2DevdockAssemblyLifecycle'
+}
+
 tasks.register('api2DevdockTusAssembly', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'com.transloadit.examples.Api2DevdockTusAssembly'

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -10,6 +10,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 repositories {
+    mavenCentral()
     jcenter()
 }
 
@@ -36,4 +37,9 @@ compileTestKotlin {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_1_8)
     }
+}
+
+tasks.register('api2DevdockTemplateLifecycle', JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'com.transloadit.examples.Api2DevdockTemplateLifecycle'
 }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -54,3 +54,8 @@ tasks.register('api2DevdockTusAssembly', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'com.transloadit.examples.Api2DevdockTusAssembly'
 }
+
+tasks.register('api2DevdockTusResumeUpload', JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'com.transloadit.examples.Api2DevdockTusResumeUpload'
+}

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -16,6 +16,7 @@ repositories {
 
 dependencies {
     implementation rootProject
+    implementation 'io.tus.java.client:tus-java-client:0.5.1'
     implementation 'org.json:json:20231013'
 }
 buildscript {
@@ -42,4 +43,9 @@ compileTestKotlin {
 tasks.register('api2DevdockTemplateLifecycle', JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'com.transloadit.examples.Api2DevdockTemplateLifecycle'
+}
+
+tasks.register('api2DevdockTusAssembly', JavaExec) {
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'com.transloadit.examples.Api2DevdockTusAssembly'
 }

--- a/examples/src/main/java/com/transloadit/examples/Api2DevdockAssemblyLifecycle.java
+++ b/examples/src/main/java/com/transloadit/examples/Api2DevdockAssemblyLifecycle.java
@@ -1,0 +1,117 @@
+package com.transloadit.examples;
+
+import com.transloadit.sdk.Transloadit;
+import com.transloadit.sdk.response.AssemblyResponse;
+import com.transloadit.sdk.response.ListResponse;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Runs API2's contract-owned Assembly lifecycle scenario against devdock.
+ */
+public final class Api2DevdockAssemblyLifecycle {
+    /**
+     * Runs the Assembly lifecycle scenario.
+     *
+     * @param args ignored
+     * @throws Exception if the scenario cannot be completed
+     */
+    public static void main(String[] args) throws Exception {
+        JSONObject scenario = loadScenario();
+        Transloadit transloadit = new Transloadit(
+                requiredEnv("TRANSLOADIT_KEY"),
+                requiredEnv("TRANSLOADIT_SECRET"),
+                requiredEnv("TRANSLOADIT_ENDPOINT"));
+
+        AssemblyResponse created = transloadit.createTusAssembly(
+                scenario.getJSONObject("assembly").getInt("fileCount"));
+        String createdAssemblySslUrl = created.getSslUrl();
+        boolean cancelAssembly = true;
+
+        try {
+            AssemblyResponse fetched = transloadit.getAssemblyByUrl(createdAssemblySslUrl);
+
+            Map<String, Object> listOptions = new HashMap<String, Object>();
+            listOptions.put("assembly_id", created.getId());
+            listOptions.put("pagesize", scenario.getJSONObject("list").getInt("pageSize"));
+            ListResponse listed = transloadit.listAssemblies(listOptions);
+
+            AssemblyResponse cancelled = transloadit.cancelAssembly(createdAssemblySslUrl);
+            cancelAssembly = false;
+
+            JSONObject result = new JSONObject();
+            result.put("cancelled", assemblyResult(cancelled));
+            result.put("created", assemblyResult(created));
+            result.put("fetched", assemblyResult(fetched));
+            result.put("listContainsCreated", listContainsAssembly(listed.getItems(), created.getId()));
+            result.put("listCount", listed.size());
+            writeResult(result);
+        } finally {
+            if (cancelAssembly) {
+                transloadit.cancelAssembly(createdAssemblySslUrl);
+            }
+        }
+
+        System.out.println("Java SDK devdock scenario " + scenario.getString("scenarioId")
+                + " canceled Assembly " + created.getId());
+    }
+
+    private static JSONObject assemblyResult(AssemblyResponse response) {
+        JSONObject result = new JSONObject();
+        result.put("assemblyId", response.getId());
+        result.put("assemblySslUrl", response.getSslUrl());
+        result.put("assemblyUrl", response.getUrl());
+        result.put("ok", response.json().optString("ok", ""));
+        return result;
+    }
+
+    private static boolean listContainsAssembly(JSONArray items, String assemblyId) {
+        for (int index = 0; index < items.length(); index += 1) {
+            if (assemblyId.equals(items.getJSONObject(index).optString("id"))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static JSONObject loadScenario() throws Exception {
+        String scenarioPath = System.getenv("API2_SDK_EXAMPLE_SCENARIO");
+        if (scenarioPath == null || scenarioPath.isEmpty()) {
+            scenarioPath = "examples/api2-devdock-assembly-lifecycle/api2-scenario.json";
+        }
+
+        byte[] contents = Files.readAllBytes(Paths.get(scenarioPath));
+        return new JSONObject(new String(contents, StandardCharsets.UTF_8));
+    }
+
+    private static String requiredEnv(String name) {
+        String value = System.getenv(name);
+        if (value == null || value.isEmpty()) {
+            throw new IllegalStateException(name + " must be set");
+        }
+
+        return value;
+    }
+
+    private static void writeResult(JSONObject result) throws Exception {
+        String resultPath = System.getenv("API2_SDK_EXAMPLE_RESULT");
+        if (resultPath == null || resultPath.isEmpty()) {
+            return;
+        }
+
+        Files.write(
+                Paths.get(resultPath),
+                (result.toString(2) + "\n").getBytes(StandardCharsets.UTF_8));
+    }
+
+    private Api2DevdockAssemblyLifecycle() {
+        throw new IllegalStateException("Utility class");
+    }
+}

--- a/examples/src/main/java/com/transloadit/examples/Api2DevdockAssemblyLifecycle.java
+++ b/examples/src/main/java/com/transloadit/examples/Api2DevdockAssemblyLifecycle.java
@@ -40,7 +40,16 @@ public final class Api2DevdockAssemblyLifecycle {
             Map<String, Object> listOptions = new HashMap<String, Object>();
             listOptions.put("assembly_id", created.getId());
             listOptions.put("pagesize", scenario.getJSONObject("list").getInt("pageSize"));
+            // The Assembly list is eventually consistent: the API acknowledges creation before
+            // the list storage row lands, so poll briefly until the created Assembly shows up.
             ListResponse listed = transloadit.listAssemblies(listOptions);
+            for (int attempt = 0; attempt < 20; attempt += 1) {
+                if (listContainsAssembly(listed.getItems(), created.getId())) {
+                    break;
+                }
+                Thread.sleep(500);
+                listed = transloadit.listAssemblies(listOptions);
+            }
 
             AssemblyResponse cancelled = transloadit.cancelAssembly(createdAssemblySslUrl);
             cancelAssembly = false;

--- a/examples/src/main/java/com/transloadit/examples/Api2DevdockTemplateLifecycle.java
+++ b/examples/src/main/java/com/transloadit/examples/Api2DevdockTemplateLifecycle.java
@@ -1,0 +1,177 @@
+package com.transloadit.examples;
+
+import com.transloadit.sdk.Transloadit;
+import com.transloadit.sdk.response.ListResponse;
+import com.transloadit.sdk.response.Response;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Runs API2's contract-owned Template lifecycle scenario against devdock.
+ */
+public final class Api2DevdockTemplateLifecycle {
+    /**
+     * Runs the Template lifecycle scenario.
+     *
+     * @param args ignored
+     * @throws Exception if the scenario cannot be completed
+     */
+    public static void main(String[] args) throws Exception {
+        JSONObject scenario = loadScenario();
+        Transloadit transloadit = new Transloadit(
+                requiredEnv("TRANSLOADIT_KEY"),
+                requiredEnv("TRANSLOADIT_SECRET"),
+                requiredEnv("TRANSLOADIT_ENDPOINT"));
+
+        JSONObject templateConfig = scenario.getJSONObject("template");
+        JSONObject updateConfig = scenario.getJSONObject("update");
+        String templateName = templateConfig.getString("namePrefix") + "-" + System.currentTimeMillis();
+
+        Response created = transloadit.createTemplate(templatePayload(templateName, templateConfig));
+        String templateId = created.json().getString("id");
+        boolean deleteTemplate = true;
+
+        try {
+            Response fetched = transloadit.getTemplate(templateId);
+
+            Map<String, Object> listOptions = new HashMap<String, Object>();
+            listOptions.put("pagesize", scenario.getJSONObject("list").getInt("pageSize"));
+            ListResponse listed = transloadit.listTemplates(listOptions);
+
+            String updatedTemplateName = templateName + updateConfig.getString("nameSuffix");
+            transloadit.updateTemplate(templateId, templatePayload(updatedTemplateName, updateConfig));
+            Response updated = transloadit.getTemplate(templateId);
+
+            transloadit.deleteTemplate(templateId);
+            deleteTemplate = false;
+
+            JSONObject result = new JSONObject();
+            JSONObject deletedGet = deletedGetResult(transloadit, templateId);
+            for (Iterator<String> keys = deletedGet.keys(); keys.hasNext();) {
+                String key = keys.next();
+                result.put(key, deletedGet.get(key));
+            }
+            result.put("fetched", templateResult(fetched.json()));
+            result.put("listCount", listed.size());
+            result.put("templateId", templateId);
+            result.put("templateName", templateName);
+            result.put("updated", templateResult(updated.json()));
+            result.put("updatedTemplateName", updatedTemplateName);
+            writeResult(result);
+        } finally {
+            if (deleteTemplate) {
+                transloadit.deleteTemplate(templateId);
+            }
+        }
+
+        System.out.println("Java SDK devdock scenario " + scenario.getString("scenarioId")
+                + " passed for " + templateId);
+    }
+
+    private static JSONObject deletedGetResult(Transloadit transloadit, String templateId) throws Exception {
+        Response response = transloadit.getTemplate(templateId);
+        JSONObject body = response.json();
+        boolean succeeded = response.status() >= 200 && response.status() < 300 && !body.has("error");
+
+        JSONObject result = new JSONObject();
+        result.put("deletedGetSucceeded", succeeded);
+        result.put("deletedErrorCode", body.optString("error", body.optString("ok", "")));
+        return result;
+    }
+
+    private static JSONObject loadScenario() throws Exception {
+        String scenarioPath = System.getenv("API2_SDK_EXAMPLE_SCENARIO");
+        if (scenarioPath == null || scenarioPath.isEmpty()) {
+            scenarioPath = "examples/api2-devdock-template-lifecycle/api2-scenario.json";
+        }
+
+        byte[] contents = Files.readAllBytes(Paths.get(scenarioPath));
+        return new JSONObject(new String(contents, StandardCharsets.UTF_8));
+    }
+
+    private static String requiredEnv(String name) {
+        String value = System.getenv(name);
+        if (value == null || value.isEmpty()) {
+            throw new IllegalStateException(name + " must be set");
+        }
+
+        return value;
+    }
+
+    private static Map<String, Object> templatePayload(String name, JSONObject config) {
+        JSONObject content = config.getJSONObject("content");
+        Map<String, Object> template = jsonObjectToMap(content.getJSONObject("additionalProperties"));
+        template.put("steps", jsonObjectToMap(content.getJSONObject("steps")));
+
+        Map<String, Object> payload = new HashMap<String, Object>();
+        payload.put("name", name);
+        payload.put("require_signature_auth", config.getBoolean("requireSignatureAuth") ? 1 : 0);
+        payload.put("template", template);
+        return payload;
+    }
+
+    private static JSONObject templateResult(JSONObject template) {
+        JSONObject result = new JSONObject();
+        result.put("content", template.getJSONObject("content"));
+        result.put("id", template.getString("id"));
+        result.put("name", template.getString("name"));
+        result.put("requireSignatureAuth", template.getInt("require_signature_auth") != 0);
+        return result;
+    }
+
+    private static Map<String, Object> jsonObjectToMap(JSONObject object) {
+        Map<String, Object> map = new HashMap<String, Object>();
+        for (Iterator<String> keys = object.keys(); keys.hasNext();) {
+            String key = keys.next();
+            map.put(key, jsonValueToJava(object.get(key)));
+        }
+
+        return map;
+    }
+
+    private static Object jsonValueToJava(Object value) {
+        if (value == JSONObject.NULL) {
+            return null;
+        }
+
+        if (value instanceof JSONObject) {
+            return jsonObjectToMap((JSONObject) value);
+        }
+
+        if (value instanceof JSONArray) {
+            JSONArray array = (JSONArray) value;
+            List<Object> list = new ArrayList<Object>();
+            for (int index = 0; index < array.length(); index += 1) {
+                list.add(jsonValueToJava(array.get(index)));
+            }
+
+            return list;
+        }
+
+        return value;
+    }
+
+    private static void writeResult(JSONObject result) throws Exception {
+        String resultPath = System.getenv("API2_SDK_EXAMPLE_RESULT");
+        if (resultPath == null || resultPath.isEmpty()) {
+            return;
+        }
+
+        Files.write(
+                Paths.get(resultPath),
+                (result.toString(2) + "\n").getBytes(StandardCharsets.UTF_8));
+    }
+
+    private Api2DevdockTemplateLifecycle() {
+        throw new IllegalStateException("Utility class");
+    }
+}

--- a/examples/src/main/java/com/transloadit/examples/Api2DevdockTusAssembly.java
+++ b/examples/src/main/java/com/transloadit/examples/Api2DevdockTusAssembly.java
@@ -1,0 +1,181 @@
+package com.transloadit.examples;
+
+import com.transloadit.sdk.Transloadit;
+import com.transloadit.sdk.response.AssemblyResponse;
+import io.tus.java.client.TusClient;
+import io.tus.java.client.TusUpload;
+import io.tus.java.client.TusUploader;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.ByteArrayInputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Runs API2's contract-owned TUS Assembly scenario against devdock.
+ */
+public final class Api2DevdockTusAssembly {
+    /**
+     * Runs the TUS Assembly scenario.
+     *
+     * @param args ignored
+     * @throws Exception if the scenario cannot be completed
+     */
+    public static void main(String[] args) throws Exception {
+        JSONObject scenario = loadScenario();
+        Transloadit transloadit = new Transloadit(
+                requiredEnv("TRANSLOADIT_KEY"),
+                requiredEnv("TRANSLOADIT_SECRET"),
+                requiredEnv("TRANSLOADIT_ENDPOINT"));
+
+        JSONObject createRequest = scenario.getJSONObject("createTusAssembly").getJSONObject("request");
+        AssemblyResponse created = transloadit.createAssembly(
+                jsonObjectToMap(createRequest.getJSONObject("normalizedParams")),
+                jsonObjectToStringMap(createRequest.getJSONObject("formFields")));
+        JSONObject createResponse = created.json();
+
+        String uploadUrl = uploadScenarioBytes(scenario, createResponse);
+
+        JSONObject result = new JSONObject();
+        result.put("createResponse", createResponse);
+        result.put("uploadUrl", uploadUrl);
+        writeResult(result);
+
+        System.out.println("Java SDK devdock scenario " + scenario.getString("scenarioId")
+                + " uploaded to " + uploadUrl);
+    }
+
+    private static JSONObject loadScenario() throws Exception {
+        String scenarioPath = System.getenv("API2_SDK_EXAMPLE_SCENARIO");
+        if (scenarioPath == null || scenarioPath.isEmpty()) {
+            scenarioPath = "examples/api2-devdock-tus-assembly/api2-scenario.json";
+        }
+
+        byte[] contents = Files.readAllBytes(Paths.get(scenarioPath));
+        return new JSONObject(new String(contents, StandardCharsets.UTF_8));
+    }
+
+    private static String requiredEnv(String name) {
+        String value = System.getenv(name);
+        if (value == null || value.isEmpty()) {
+            throw new IllegalStateException(name + " must be set");
+        }
+
+        return value;
+    }
+
+    private static String uploadScenarioBytes(JSONObject scenario, JSONObject createResponse) throws Exception {
+        JSONObject uploadConfig = scenario.getJSONObject("upload");
+        JSONObject source = uploadConfig.getJSONObject("source");
+        byte[] bytes = source.getString("value").getBytes(StandardCharsets.UTF_8);
+
+        TusClient tusClient = new TusClient();
+        tusClient.setUploadCreationURL(new URL(createResponse.getString("tus_url")));
+
+        TusUpload upload = new TusUpload();
+        upload.setInputStream(new ByteArrayInputStream(bytes));
+        upload.setSize(bytes.length);
+        upload.setFingerprint("api2-devdock-java-sdk-" + createResponse.getString("assembly_id"));
+        upload.setMetadata(uploadMetadata(scenario, createResponse));
+
+        TusUploader uploader = tusClient.createUpload(upload);
+        uploader.setChunkSize(bytes.length);
+        while (uploader.uploadChunk() > -1) {
+            // Upload the single scenario-owned source until tus-java-client reports completion.
+        }
+        uploader.finish(false);
+
+        return uploader.getUploadURL().toString();
+    }
+
+    private static Map<String, String> uploadMetadata(
+            JSONObject scenario,
+            JSONObject createResponse) {
+        Map<String, String> metadata = new HashMap<String, String>();
+        JSONArray fields = scenario.getJSONObject("upload").getJSONArray("metadata");
+        for (int index = 0; index < fields.length(); index += 1) {
+            JSONObject field = fields.getJSONObject(index);
+            metadata.put(field.getString("name"), String.valueOf(resolveScenarioValue(
+                    field.getJSONObject("value"),
+                    scenario,
+                    createResponse)));
+        }
+
+        return metadata;
+    }
+
+    private static Object resolveScenarioValue(
+            JSONObject value,
+            JSONObject scenario,
+            JSONObject createResponse) {
+        if (value.has("value")) {
+            return value.get("value");
+        }
+
+        JSONObject source = value.getJSONObject("source");
+        Object current;
+        if ("scenario".equals(source.getString("root"))) {
+            current = scenario;
+        } else if ("createResponse".equals(source.getString("root"))) {
+            current = createResponse;
+        } else {
+            throw new IllegalStateException("Unsupported scenario value root: " + source.getString("root"));
+        }
+
+        JSONArray path = source.getJSONArray("path");
+        for (int index = 0; index < path.length(); index += 1) {
+            if (!(current instanceof JSONObject)) {
+                throw new IllegalStateException("Cannot resolve scenario path through non-object value");
+            }
+
+            current = ((JSONObject) current).get(path.getString(index));
+        }
+
+        return current;
+    }
+
+    private static Map<String, Object> jsonObjectToMap(JSONObject object) {
+        Map<String, Object> map = new HashMap<String, Object>();
+        for (Iterator<String> keys = object.keys(); keys.hasNext();) {
+            String key = keys.next();
+            Object value = object.get(key);
+            if (value instanceof JSONObject) {
+                value = jsonObjectToMap((JSONObject) value);
+            }
+            map.put(key, value);
+        }
+
+        return map;
+    }
+
+    private static Map<String, String> jsonObjectToStringMap(JSONObject object) {
+        Map<String, String> map = new HashMap<String, String>();
+        for (Iterator<String> keys = object.keys(); keys.hasNext();) {
+            String key = keys.next();
+            map.put(key, String.valueOf(object.get(key)));
+        }
+
+        return map;
+    }
+
+    private static void writeResult(JSONObject result) throws Exception {
+        String resultPath = System.getenv("API2_SDK_EXAMPLE_RESULT");
+        if (resultPath == null || resultPath.isEmpty()) {
+            return;
+        }
+
+        Files.write(
+                Paths.get(resultPath),
+                (result.toString(2) + "\n").getBytes(StandardCharsets.UTF_8));
+    }
+
+    private Api2DevdockTusAssembly() {
+        throw new IllegalStateException("Utility class");
+    }
+}

--- a/examples/src/main/java/com/transloadit/examples/Api2DevdockTusAssembly.java
+++ b/examples/src/main/java/com/transloadit/examples/Api2DevdockTusAssembly.java
@@ -14,7 +14,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -34,10 +33,10 @@ public final class Api2DevdockTusAssembly {
                 requiredEnv("TRANSLOADIT_SECRET"),
                 requiredEnv("TRANSLOADIT_ENDPOINT"));
 
-        JSONObject createRequest = scenario.getJSONObject("createTusAssembly").getJSONObject("request");
-        AssemblyResponse created = transloadit.createAssembly(
-                jsonObjectToMap(createRequest.getJSONObject("normalizedParams")),
-                jsonObjectToStringMap(createRequest.getJSONObject("formFields")));
+        int fileCount = scenario.getJSONObject("createTusAssembly")
+                .getJSONObject("input")
+                .getInt("file_count");
+        AssemblyResponse created = transloadit.createTusAssembly(fileCount);
         JSONObject createResponse = created.json();
 
         String uploadUrl = uploadScenarioBytes(scenario, createResponse);
@@ -138,30 +137,6 @@ public final class Api2DevdockTusAssembly {
         }
 
         return current;
-    }
-
-    private static Map<String, Object> jsonObjectToMap(JSONObject object) {
-        Map<String, Object> map = new HashMap<String, Object>();
-        for (Iterator<String> keys = object.keys(); keys.hasNext();) {
-            String key = keys.next();
-            Object value = object.get(key);
-            if (value instanceof JSONObject) {
-                value = jsonObjectToMap((JSONObject) value);
-            }
-            map.put(key, value);
-        }
-
-        return map;
-    }
-
-    private static Map<String, String> jsonObjectToStringMap(JSONObject object) {
-        Map<String, String> map = new HashMap<String, String>();
-        for (Iterator<String> keys = object.keys(); keys.hasNext();) {
-            String key = keys.next();
-            map.put(key, String.valueOf(object.get(key)));
-        }
-
-        return map;
     }
 
     private static void writeResult(JSONObject result) throws Exception {

--- a/examples/src/main/java/com/transloadit/examples/Api2DevdockTusAssembly.java
+++ b/examples/src/main/java/com/transloadit/examples/Api2DevdockTusAssembly.java
@@ -2,7 +2,6 @@ package com.transloadit.examples;
 
 import com.transloadit.sdk.Transloadit;
 import com.transloadit.sdk.UploadTusAssemblyResult;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.nio.charset.StandardCharsets;
@@ -29,7 +28,10 @@ public final class Api2DevdockTusAssembly {
                 requiredEnv("TRANSLOADIT_SECRET"),
                 requiredEnv("TRANSLOADIT_ENDPOINT"));
 
-        JSONObject input = sdkFeatureCall(scenario, "uploadTusAssembly").getJSONObject("input");
+        JSONObject exampleInput = scenario.getJSONObject("exampleInput");
+        JSONObject input = exampleInput
+                .getJSONObject("sdkFeatureInputs")
+                .getJSONObject("uploadTusAssembly");
         int fileCount = input.getInt("file_count");
 
         JSONObject uploadConfig = input.getJSONObject("upload");
@@ -48,7 +50,7 @@ public final class Api2DevdockTusAssembly {
         result.put("uploadUrl", uploadResult.getUploadUrl());
         writeResult(result);
 
-        System.out.println("Java SDK devdock scenario " + scenario.getString("scenarioId")
+        System.out.println("Java SDK devdock scenario " + exampleInput.getString("scenarioId")
                 + " uploaded to " + uploadResult.getUploadUrl()
                 + " and finished with " + status.getString("ok"));
     }
@@ -61,24 +63,6 @@ public final class Api2DevdockTusAssembly {
 
         byte[] contents = Files.readAllBytes(Paths.get(scenarioPath));
         return new JSONObject(new String(contents, StandardCharsets.UTF_8));
-    }
-
-    private static JSONObject sdkFeatureCall(JSONObject scenario, String featureId) {
-        JSONArray featureCalls = scenario.getJSONArray("sdkFeatureCalls");
-        for (int index = 0; index < featureCalls.length(); index += 1) {
-            JSONObject featureCall = featureCalls.getJSONObject(index);
-            if (!featureId.equals(featureCall.getString("featureId"))) {
-                continue;
-            }
-            if (!"sdk-feature-call".equals(featureCall.getString("kind"))) {
-                throw new IllegalStateException("sdkFeatureCalls[" + index
-                        + "] must have kind sdk-feature-call");
-            }
-
-            return featureCall;
-        }
-
-        throw new IllegalStateException("Scenario has no SDK feature call for feature " + featureId);
     }
 
     private static String requiredEnv(String name) {

--- a/examples/src/main/java/com/transloadit/examples/Api2DevdockTusAssembly.java
+++ b/examples/src/main/java/com/transloadit/examples/Api2DevdockTusAssembly.java
@@ -1,19 +1,15 @@
 package com.transloadit.examples;
 
 import com.transloadit.sdk.Transloadit;
-import com.transloadit.sdk.response.AssemblyResponse;
-import io.tus.java.client.TusClient;
-import io.tus.java.client.TusUpload;
-import io.tus.java.client.TusUploader;
+import com.transloadit.sdk.UploadTusAssemblyResult;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.io.ByteArrayInputStream;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -40,22 +36,27 @@ public final class Api2DevdockTusAssembly {
                 "feature-call")
                 .getJSONObject("input")
                 .getInt("file_count");
-        AssemblyResponse created = transloadit.createTusAssembly(fileCount);
-        JSONObject createResponse = created.json();
 
-        String uploadUrl = uploadScenarioBytes(scenario, createResponse);
-        AssemblyResponse completed = transloadit.waitForAssembly(
-                createResponse.getString("assembly_ssl_url"));
-        JSONObject status = completed.json();
+        JSONObject uploadConfig = scenario.getJSONObject("upload");
+        JSONObject source = uploadConfig.getJSONObject("source");
+        byte[] bytes = source.getString("value").getBytes(StandardCharsets.UTF_8);
+        UploadTusAssemblyResult uploadResult = transloadit.uploadTusAssembly(
+                fileCount,
+                bytes,
+                uploadConfig.getString("fieldName"),
+                uploadConfig.getString("fileName"),
+                uploadUserMeta(uploadConfig));
+        JSONObject status = uploadResult.getAssembly().json();
 
         JSONObject result = new JSONObject();
-        result.put("createResponse", createResponse);
+        result.put("createResponse", status);
         result.put("status", status);
-        result.put("uploadUrl", uploadUrl);
+        result.put("uploadUrl", uploadResult.getUploadUrl());
         writeResult(result);
 
         System.out.println("Java SDK devdock scenario " + scenario.getString("scenarioId")
-                + " uploaded to " + uploadUrl + " and finished with " + status.getString("ok"));
+                + " uploaded to " + uploadResult.getUploadUrl()
+                + " and finished with " + status.getString("ok"));
     }
 
     private static JSONObject loadScenario() throws Exception {
@@ -100,74 +101,19 @@ public final class Api2DevdockTusAssembly {
         return value;
     }
 
-    private static String uploadScenarioBytes(JSONObject scenario, JSONObject createResponse) throws Exception {
-        JSONObject uploadConfig = scenario.getJSONObject("upload");
-        JSONObject source = uploadConfig.getJSONObject("source");
-        byte[] bytes = source.getString("value").getBytes(StandardCharsets.UTF_8);
-
-        TusClient tusClient = new TusClient();
-        tusClient.setUploadCreationURL(new URL(createResponse.getString("tus_url")));
-
-        TusUpload upload = new TusUpload();
-        upload.setInputStream(new ByteArrayInputStream(bytes));
-        upload.setSize(bytes.length);
-        upload.setFingerprint("api2-devdock-java-sdk-" + createResponse.getString("assembly_id"));
-        upload.setMetadata(uploadMetadata(scenario, createResponse));
-
-        TusUploader uploader = tusClient.createUpload(upload);
-        uploader.setChunkSize(bytes.length);
-        while (uploader.uploadChunk() > -1) {
-            // Upload the single scenario-owned source until tus-java-client reports completion.
-        }
-        uploader.finish(false);
-
-        return uploader.getUploadURL().toString();
-    }
-
-    private static Map<String, String> uploadMetadata(
-            JSONObject scenario,
-            JSONObject createResponse) {
+    private static Map<String, String> uploadUserMeta(JSONObject uploadConfig) {
         Map<String, String> metadata = new HashMap<String, String>();
-        JSONArray fields = scenario.getJSONObject("upload").getJSONArray("metadata");
-        for (int index = 0; index < fields.length(); index += 1) {
-            JSONObject field = fields.getJSONObject(index);
-            metadata.put(field.getString("name"), String.valueOf(resolveScenarioValue(
-                    field.getJSONObject("value"),
-                    scenario,
-                    createResponse)));
+        if (!uploadConfig.has("userMeta")) {
+            return metadata;
+        }
+
+        JSONObject userMeta = uploadConfig.getJSONObject("userMeta");
+        for (Iterator<String> keys = userMeta.keys(); keys.hasNext();) {
+            String key = keys.next();
+            metadata.put(key, String.valueOf(userMeta.get(key)));
         }
 
         return metadata;
-    }
-
-    private static Object resolveScenarioValue(
-            JSONObject value,
-            JSONObject scenario,
-            JSONObject createResponse) {
-        if (value.has("value")) {
-            return value.get("value");
-        }
-
-        JSONObject source = value.getJSONObject("source");
-        Object current;
-        if ("scenario".equals(source.getString("root"))) {
-            current = scenario;
-        } else if ("createResponse".equals(source.getString("root"))) {
-            current = createResponse;
-        } else {
-            throw new IllegalStateException("Unsupported scenario value root: " + source.getString("root"));
-        }
-
-        JSONArray path = source.getJSONArray("path");
-        for (int index = 0; index < path.length(); index += 1) {
-            if (!(current instanceof JSONObject)) {
-                throw new IllegalStateException("Cannot resolve scenario path through non-object value");
-            }
-
-            current = ((JSONObject) current).get(path.getString(index));
-        }
-
-        return current;
     }
 
     private static void writeResult(JSONObject result) throws Exception {

--- a/examples/src/main/java/com/transloadit/examples/Api2DevdockTusAssembly.java
+++ b/examples/src/main/java/com/transloadit/examples/Api2DevdockTusAssembly.java
@@ -40,14 +40,18 @@ public final class Api2DevdockTusAssembly {
         JSONObject createResponse = created.json();
 
         String uploadUrl = uploadScenarioBytes(scenario, createResponse);
+        AssemblyResponse completed = transloadit.waitForAssembly(
+                createResponse.getString("assembly_ssl_url"));
+        JSONObject status = completed.json();
 
         JSONObject result = new JSONObject();
         result.put("createResponse", createResponse);
+        result.put("status", status);
         result.put("uploadUrl", uploadUrl);
         writeResult(result);
 
         System.out.println("Java SDK devdock scenario " + scenario.getString("scenarioId")
-                + " uploaded to " + uploadUrl);
+                + " uploaded to " + uploadUrl + " and finished with " + status.getString("ok"));
     }
 
     private static JSONObject loadScenario() throws Exception {

--- a/examples/src/main/java/com/transloadit/examples/Api2DevdockTusAssembly.java
+++ b/examples/src/main/java/com/transloadit/examples/Api2DevdockTusAssembly.java
@@ -29,22 +29,16 @@ public final class Api2DevdockTusAssembly {
                 requiredEnv("TRANSLOADIT_SECRET"),
                 requiredEnv("TRANSLOADIT_ENDPOINT"));
 
-        int fileCount = featureStep(
-                scenario,
-                "preparations",
-                "createTusAssembly",
-                "feature-call")
-                .getJSONObject("input")
-                .getInt("file_count");
+        JSONObject input = sdkFeatureCall(scenario, "uploadTusAssembly").getJSONObject("input");
+        int fileCount = input.getInt("file_count");
 
-        JSONObject uploadConfig = scenario.getJSONObject("upload");
-        JSONObject source = uploadConfig.getJSONObject("source");
-        byte[] bytes = source.getString("value").getBytes(StandardCharsets.UTF_8);
+        JSONObject uploadConfig = input.getJSONObject("upload");
+        byte[] bytes = uploadConfig.getString("content").getBytes(StandardCharsets.UTF_8);
         UploadTusAssemblyResult uploadResult = transloadit.uploadTusAssembly(
                 fileCount,
                 bytes,
-                uploadConfig.getString("fieldName"),
-                uploadConfig.getString("fileName"),
+                uploadConfig.getString("fieldname"),
+                uploadConfig.getString("filename"),
                 uploadUserMeta(uploadConfig));
         JSONObject status = uploadResult.getAssembly().json();
 
@@ -69,27 +63,22 @@ public final class Api2DevdockTusAssembly {
         return new JSONObject(new String(contents, StandardCharsets.UTF_8));
     }
 
-    private static JSONObject featureStep(
-            JSONObject scenario,
-            String collectionName,
-            String featureId,
-            String kind) {
-        JSONArray steps = scenario.getJSONArray(collectionName);
-        for (int index = 0; index < steps.length(); index += 1) {
-            JSONObject step = steps.getJSONObject(index);
-            if (!featureId.equals(step.getString("featureId"))) {
+    private static JSONObject sdkFeatureCall(JSONObject scenario, String featureId) {
+        JSONArray featureCalls = scenario.getJSONArray("sdkFeatureCalls");
+        for (int index = 0; index < featureCalls.length(); index += 1) {
+            JSONObject featureCall = featureCalls.getJSONObject(index);
+            if (!featureId.equals(featureCall.getString("featureId"))) {
                 continue;
             }
-            if (!kind.equals(step.getString("kind"))) {
-                throw new IllegalStateException(collectionName + "[" + index
-                        + "] must have kind " + kind);
+            if (!"sdk-feature-call".equals(featureCall.getString("kind"))) {
+                throw new IllegalStateException("sdkFeatureCalls[" + index
+                        + "] must have kind sdk-feature-call");
             }
 
-            return step;
+            return featureCall;
         }
 
-        throw new IllegalStateException("Scenario has no " + collectionName
-                + " step for feature " + featureId);
+        throw new IllegalStateException("Scenario has no SDK feature call for feature " + featureId);
     }
 
     private static String requiredEnv(String name) {
@@ -103,11 +92,11 @@ public final class Api2DevdockTusAssembly {
 
     private static Map<String, String> uploadUserMeta(JSONObject uploadConfig) {
         Map<String, String> metadata = new HashMap<String, String>();
-        if (!uploadConfig.has("userMeta")) {
+        if (!uploadConfig.has("user_meta")) {
             return metadata;
         }
 
-        JSONObject userMeta = uploadConfig.getJSONObject("userMeta");
+        JSONObject userMeta = uploadConfig.getJSONObject("user_meta");
         for (Iterator<String> keys = userMeta.keys(); keys.hasNext();) {
             String key = keys.next();
             metadata.put(key, String.valueOf(userMeta.get(key)));

--- a/examples/src/main/java/com/transloadit/examples/Api2DevdockTusAssembly.java
+++ b/examples/src/main/java/com/transloadit/examples/Api2DevdockTusAssembly.java
@@ -32,12 +32,9 @@ public final class Api2DevdockTusAssembly {
         JSONObject input = exampleInput
                 .getJSONObject("sdkFeatureInputs")
                 .getJSONObject("uploadTusAssembly");
-        int fileCount = input.getInt("file_count");
-
         JSONObject uploadConfig = input.getJSONObject("upload");
         byte[] bytes = uploadConfig.getString("content").getBytes(StandardCharsets.UTF_8);
         UploadTusAssemblyResult uploadResult = transloadit.uploadTusAssembly(
-                fileCount,
                 bytes,
                 uploadConfig.getString("fieldname"),
                 uploadConfig.getString("filename"),

--- a/examples/src/main/java/com/transloadit/examples/Api2DevdockTusAssembly.java
+++ b/examples/src/main/java/com/transloadit/examples/Api2DevdockTusAssembly.java
@@ -33,7 +33,11 @@ public final class Api2DevdockTusAssembly {
                 requiredEnv("TRANSLOADIT_SECRET"),
                 requiredEnv("TRANSLOADIT_ENDPOINT"));
 
-        int fileCount = scenario.getJSONObject("createTusAssembly")
+        int fileCount = featureStep(
+                scenario,
+                "preparations",
+                "createTusAssembly",
+                "feature-call")
                 .getJSONObject("input")
                 .getInt("file_count");
         AssemblyResponse created = transloadit.createTusAssembly(fileCount);
@@ -62,6 +66,29 @@ public final class Api2DevdockTusAssembly {
 
         byte[] contents = Files.readAllBytes(Paths.get(scenarioPath));
         return new JSONObject(new String(contents, StandardCharsets.UTF_8));
+    }
+
+    private static JSONObject featureStep(
+            JSONObject scenario,
+            String collectionName,
+            String featureId,
+            String kind) {
+        JSONArray steps = scenario.getJSONArray(collectionName);
+        for (int index = 0; index < steps.length(); index += 1) {
+            JSONObject step = steps.getJSONObject(index);
+            if (!featureId.equals(step.getString("featureId"))) {
+                continue;
+            }
+            if (!kind.equals(step.getString("kind"))) {
+                throw new IllegalStateException(collectionName + "[" + index
+                        + "] must have kind " + kind);
+            }
+
+            return step;
+        }
+
+        throw new IllegalStateException("Scenario has no " + collectionName
+                + " step for feature " + featureId);
     }
 
     private static String requiredEnv(String name) {

--- a/examples/src/main/java/com/transloadit/examples/Api2DevdockTusResumeUpload.java
+++ b/examples/src/main/java/com/transloadit/examples/Api2DevdockTusResumeUpload.java
@@ -1,0 +1,234 @@
+package com.transloadit.examples;
+
+import com.transloadit.sdk.Transloadit;
+import com.transloadit.sdk.response.AssemblyResponse;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Runs API2's contract-owned TUS resume scenario against devdock.
+ *
+ * <p>This example is intentionally checked into the SDK repository: it reads the
+ * API/TUS facts from API2's injected scenario JSON, interrupts an upload like an
+ * unlucky user would, and resumes it through the public SDK method.</p>
+ */
+public final class Api2DevdockTusResumeUpload {
+    /**
+     * Runs the TUS resume scenario.
+     *
+     * @param args ignored
+     * @throws Exception if the scenario cannot be completed
+     */
+    public static void main(String[] args) throws Exception {
+        JSONObject scenario = loadScenario();
+        Transloadit transloadit = new Transloadit(
+                requiredEnv("TRANSLOADIT_KEY"),
+                requiredEnv("TRANSLOADIT_SECRET"),
+                requiredEnv("TRANSLOADIT_ENDPOINT"));
+
+        JSONObject createResponse = scenario.getJSONObject("prepared").getJSONObject("createResponse");
+        JSONObject upload = scenario.getJSONObject("upload");
+        JSONObject resume = upload.getJSONObject("resume");
+
+        Map<String, Object> context = new HashMap<String, Object>();
+        context.put("createResponse", createResponse);
+        context.put("scenario", scenario);
+
+        byte[] content = scenarioBytes(upload);
+        String tusUrl = String.valueOf(resolveValue(upload.get("tusUrl"), context, "upload.tusUrl"));
+        Map<String, String> metadata = uploadMetadata(upload, context);
+
+        String firstUploadUrl = createInterruptedUpload(
+                tusUrl,
+                content,
+                metadata,
+                resume.getInt("stopAfterAcceptedBytes"));
+
+        // Remember the interrupted upload by fingerprint, like a TUS client URL storage would.
+        Map<String, String> storedUploads = new HashMap<String, String>();
+        storedUploads.put(resume.getString("fingerprint"), firstUploadUrl);
+        int previousUploadCount = storedUploads.size();
+
+        AssemblyResponse completedAssembly = transloadit.resumeTusUpload(
+                storedUploads.get(resume.getString("fingerprint")),
+                content,
+                createResponse.getString("assembly_ssl_url"));
+        JSONObject status = completedAssembly.json();
+        if (status.has("error") && !status.isNull("error")) {
+            throw new IllegalStateException("resumeTusUpload returned " + status.getString("error")
+                    + ": " + status.optString("message"));
+        }
+
+        if (resume.getBoolean("removeFingerprintOnSuccess")) {
+            storedUploads.remove(resume.getString("fingerprint"));
+        }
+        int remainingPreviousUploadCount = storedUploads.size();
+
+        JSONObject result = new JSONObject();
+        result.put("firstUploadUrl", firstUploadUrl);
+        result.put("previousUploadCount", previousUploadCount);
+        result.put("remainingPreviousUploadCount", remainingPreviousUploadCount);
+        result.put("uploadUrl", firstUploadUrl);
+        writeResult(result);
+
+        System.out.println("Java SDK devdock scenario "
+                + scenario.getJSONObject("exampleInput").getString("scenarioId")
+                + " resumed " + firstUploadUrl);
+    }
+
+    private static JSONObject loadScenario() throws Exception {
+        String scenarioPath = System.getenv("API2_SDK_EXAMPLE_SCENARIO");
+        if (scenarioPath == null || scenarioPath.isEmpty()) {
+            scenarioPath = "examples/api2-devdock-tus-resume-upload/api2-scenario.json";
+        }
+
+        byte[] contents = Files.readAllBytes(Paths.get(scenarioPath));
+        return new JSONObject(new String(contents, StandardCharsets.UTF_8));
+    }
+
+    private static String requiredEnv(String name) {
+        String value = System.getenv(name);
+        if (value == null || value.isEmpty()) {
+            throw new IllegalStateException(name + " must be set");
+        }
+
+        return value;
+    }
+
+    private static Object resolveValue(Object valueSpec, Map<String, Object> context, String label) {
+        if (!(valueSpec instanceof JSONObject)) {
+            throw new IllegalStateException(label + " value spec must be an object");
+        }
+
+        JSONObject spec = (JSONObject) valueSpec;
+        if (spec.has("value")) {
+            return spec.get("value");
+        }
+
+        JSONObject source = spec.getJSONObject("source");
+        Object current = context.get(source.getString("root"));
+        if (current == null) {
+            throw new IllegalStateException(label + " value source root is unavailable");
+        }
+        JSONArray pathParts = source.getJSONArray("path");
+        for (int index = 0; index < pathParts.length(); index += 1) {
+            String part = pathParts.getString(index);
+            if (!(current instanceof JSONObject) || !((JSONObject) current).has(part)) {
+                throw new IllegalStateException(label + " value source cannot read " + part);
+            }
+            current = ((JSONObject) current).get(part);
+        }
+
+        return current;
+    }
+
+    private static byte[] scenarioBytes(JSONObject upload) {
+        JSONObject source = upload.getJSONObject("source");
+        if (!"bytes".equals(source.getString("kind"))) {
+            throw new IllegalStateException("upload.source.kind must be bytes");
+        }
+        if (!"utf8".equals(source.getString("encoding"))) {
+            throw new IllegalStateException("upload.source.encoding must be utf8");
+        }
+
+        return source.getString("value").getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static Map<String, String> uploadMetadata(JSONObject upload, Map<String, Object> context) {
+        Map<String, String> metadata = new LinkedHashMap<String, String>();
+        JSONArray fields = upload.getJSONArray("metadata");
+        for (int index = 0; index < fields.length(); index += 1) {
+            JSONObject field = fields.getJSONObject(index);
+            String name = field.getString("name");
+            metadata.put(name, String.valueOf(resolveValue(field.get("value"), context, name)));
+        }
+
+        return metadata;
+    }
+
+    /**
+     * Creates a TUS upload and only sends the first chunk, leaving the upload
+     * interrupted the way a dropped connection would.
+     */
+    private static String createInterruptedUpload(
+            String tusUrl,
+            byte[] content,
+            Map<String, String> metadata,
+            int stopAfterAcceptedBytes) throws Exception {
+        List<String> metadataParts = new ArrayList<String>();
+        for (Map.Entry<String, String> entry : metadata.entrySet()) {
+            metadataParts.add(entry.getKey() + " "
+                    + Base64.getEncoder().encodeToString(entry.getValue().getBytes(StandardCharsets.UTF_8)));
+        }
+
+        URL createUrl = new URL(tusUrl);
+        HttpURLConnection createConnection = (HttpURLConnection) createUrl.openConnection();
+        createConnection.setRequestMethod("POST");
+        createConnection.setRequestProperty("Tus-Resumable", "1.0.0");
+        createConnection.setRequestProperty("Upload-Length", String.valueOf(content.length));
+        createConnection.setRequestProperty("Upload-Metadata", String.join(",", metadataParts));
+        createConnection.setDoOutput(true);
+        createConnection.getOutputStream().close();
+        if (createConnection.getResponseCode() != 201) {
+            throw new IllegalStateException("TUS create returned HTTP "
+                    + createConnection.getResponseCode() + ", expected 201");
+        }
+        String location = createConnection.getHeaderField("Location");
+        createConnection.disconnect();
+        if (location == null || location.isEmpty()) {
+            throw new IllegalStateException("TUS create did not return a Location header");
+        }
+        String uploadUrl = new URL(createUrl, location).toString();
+
+        HttpURLConnection patchConnection = (HttpURLConnection) new URL(uploadUrl).openConnection();
+        // HttpURLConnection rejects PATCH, so use the same POST + override header TUS supports.
+        patchConnection.setRequestMethod("POST");
+        patchConnection.setRequestProperty("X-HTTP-Method-Override", "PATCH");
+        patchConnection.setRequestProperty("Tus-Resumable", "1.0.0");
+        patchConnection.setRequestProperty("Upload-Offset", "0");
+        patchConnection.setRequestProperty("Content-Type", "application/offset+octet-stream");
+        patchConnection.setDoOutput(true);
+        patchConnection.getOutputStream().write(content, 0, stopAfterAcceptedBytes);
+        patchConnection.getOutputStream().close();
+        if (patchConnection.getResponseCode() != 204) {
+            throw new IllegalStateException("TUS first chunk returned HTTP "
+                    + patchConnection.getResponseCode() + ", expected 204");
+        }
+        String acceptedBytesHeader = patchConnection.getHeaderField("Upload-Offset");
+        patchConnection.disconnect();
+        int acceptedBytes = acceptedBytesHeader == null ? -1 : Integer.parseInt(acceptedBytesHeader);
+        if (acceptedBytes != stopAfterAcceptedBytes) {
+            throw new IllegalStateException("TUS first chunk accepted " + acceptedBytes
+                    + " bytes, expected " + stopAfterAcceptedBytes);
+        }
+
+        return uploadUrl;
+    }
+
+    private static void writeResult(JSONObject result) throws Exception {
+        String resultPath = System.getenv("API2_SDK_EXAMPLE_RESULT");
+        if (resultPath == null || resultPath.isEmpty()) {
+            return;
+        }
+
+        Files.write(
+                Paths.get(resultPath),
+                (result.toString(2) + "\n").getBytes(StandardCharsets.UTF_8));
+    }
+
+    private Api2DevdockTusResumeUpload() {
+        throw new IllegalStateException("Utility class");
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 // Uncomment following line if you want to use the local java-sdk
 // for the example instead of pulling the JARs from JCenter.
 // This is useful for debugging and testing new features.
-// include ':examples'
+include ':examples'
 rootProject.name = 'transloadit'

--- a/src/main/java/com/transloadit/sdk/Request.java
+++ b/src/main/java/com/transloadit/sdk/Request.java
@@ -552,4 +552,25 @@ public class Request {
 
     // </api2-generated-endpoint assemblyUrlRequestSupport>
 
+
+    // <api2-generated-endpoint pathSegmentEncodingSupport>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    String encodePathSegment(String value) throws LocalOperationException {
+        if (".".equals(value) || "..".equals(value)) {
+            throw new LocalOperationException("Path parameters cannot be dot segments.");
+        }
+
+        try {
+            return URLEncoder.encode(value, "UTF-8").replace("+", "%20");
+        } catch (UnsupportedEncodingException error) {
+            throw new LocalOperationException(error);
+        }
+    }
+
+    // </api2-generated-endpoint pathSegmentEncodingSupport>
+
 }

--- a/src/main/java/com/transloadit/sdk/Request.java
+++ b/src/main/java/com/transloadit/sdk/Request.java
@@ -484,4 +484,72 @@ public class Request {
         }
         return timeToWait;
     }
+
+    // <api2-generated-endpoint assemblyUrlRequestSupport>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    protected okhttp3.Response requestAssemblyUrl(String url, String method)
+            throws RequestException, LocalOperationException {
+        java.net.URI candidate;
+        java.net.URI configured;
+        try {
+            candidate = java.net.URI.create(url);
+            configured = java.net.URI.create(transloadit.getHostUrl());
+        } catch (IllegalArgumentException error) {
+            throw new LocalOperationException("Invalid Assembly URL.", error);
+        }
+
+        String candidateHost = candidate.getHost();
+        String configuredHost = configured.getHost();
+        int candidatePort = candidate.getPort() >= 0
+                ? candidate.getPort()
+                : ("https".equalsIgnoreCase(candidate.getScheme()) ? 443 : 80);
+        int configuredPort = configured.getPort() >= 0
+                ? configured.getPort()
+                : ("https".equalsIgnoreCase(configured.getScheme()) ? 443 : 80);
+        boolean configuredOrigin = candidateHost != null && configuredHost != null
+                && candidate.getScheme() != null && configured.getScheme() != null
+                && candidate.getScheme().equalsIgnoreCase(configured.getScheme())
+                && candidateHost.equalsIgnoreCase(configuredHost)
+                && candidatePort == configuredPort;
+        String normalizedHost = candidateHost == null ? "" : candidateHost.toLowerCase(java.util.Locale.ROOT);
+        boolean api2Cell = "https".equalsIgnoreCase(candidate.getScheme())
+                && candidatePort == 443
+                && normalizedHost.startsWith("api2-")
+                && normalizedHost.endsWith(".transloadit.com");
+        if (candidate.getUserInfo() != null || !(configuredOrigin || api2Cell)) {
+            throw new LocalOperationException("Refusing to request an untrusted Assembly URL.");
+        }
+
+        okhttp3.Request.Builder builder = new okhttp3.Request.Builder()
+                .url(candidate.toString())
+                .addHeader("Transloadit-Client", this.version);
+        if ("GET".equals(method)) {
+            builder.get();
+        } else if ("DELETE".equals(method)) {
+            builder.delete();
+        } else {
+            throw new LocalOperationException("Unsupported Assembly URL method: " + method);
+        }
+
+        OkHttpClient client = httpClient.newBuilder()
+                .followRedirects(false)
+                .followSslRedirects(false)
+                .build();
+        try {
+            return client.newCall(builder.build()).execute();
+        } catch (IOException error) {
+            if (qualifiedForRetry(error)) {
+                delayBeforeRetry();
+                return requestAssemblyUrl(url, method);
+            }
+            throw new RequestException(error);
+        }
+    }
+
+    // </api2-generated-endpoint assemblyUrlRequestSupport>
+
 }

--- a/src/main/java/com/transloadit/sdk/Request.java
+++ b/src/main/java/com/transloadit/sdk/Request.java
@@ -515,12 +515,16 @@ public class Request {
                 && candidate.getScheme().equalsIgnoreCase(configured.getScheme())
                 && candidateHost.equalsIgnoreCase(configuredHost)
                 && candidatePort == configuredPort;
+        boolean configuredHttpsHost = candidateHost != null && configuredHost != null
+                && "https".equalsIgnoreCase(candidate.getScheme())
+                && candidatePort == 443
+                && candidateHost.equalsIgnoreCase(configuredHost);
         String normalizedHost = candidateHost == null ? "" : candidateHost.toLowerCase(java.util.Locale.ROOT);
         boolean api2Cell = "https".equalsIgnoreCase(candidate.getScheme())
                 && candidatePort == 443
                 && normalizedHost.startsWith("api2-")
                 && normalizedHost.endsWith(".transloadit.com");
-        if (candidate.getUserInfo() != null || !(configuredOrigin || api2Cell)) {
+        if (candidate.getUserInfo() != null || !(configuredOrigin || configuredHttpsHost || api2Cell)) {
             throw new LocalOperationException("Refusing to request an untrusted Assembly URL.");
         }
 

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -1096,10 +1096,10 @@ public class Transloadit {
     // please report the issue instead of editing this block by hand; the source fix
     // belongs in the contract generator so all SDKs stay in sync.
 
-    public ListResponse listPriorityJobSlots(Map<String, Object> options)
+    public Response listPriorityJobSlots(Map<String, Object> options)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new ListResponse(request.get("/queues/job_slots", options));
+        return new Response(request.get("/queues/job_slots", options));
     }
 
     // </api2-generated-endpoint listPriorityJobSlots>
@@ -1111,10 +1111,10 @@ public class Transloadit {
     // please report the issue instead of editing this block by hand; the source fix
     // belongs in the contract generator so all SDKs stay in sync.
 
-    public ListResponse listTemplateCredentials(Map<String, Object> options)
+    public Response listTemplateCredentials(Map<String, Object> options)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new ListResponse(request.get("/template_credentials", options));
+        return new Response(request.get("/template_credentials", options));
     }
 
     // </api2-generated-endpoint listTemplateCredentials>
@@ -1126,10 +1126,10 @@ public class Transloadit {
     // please report the issue instead of editing this block by hand; the source fix
     // belongs in the contract generator so all SDKs stay in sync.
 
-    public ListResponse listTemplateCredentialTypes(Map<String, Object> options)
+    public Response listTemplateCredentialTypes(Map<String, Object> options)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new ListResponse(request.get("/template_credentials/types", options));
+        return new Response(request.get("/template_credentials/types", options));
     }
 
     // </api2-generated-endpoint listTemplateCredentialTypes>
@@ -1228,14 +1228,24 @@ public class Transloadit {
             throw new LocalOperationException("Invalid bearer token endpoint.", error);
         }
         String endpointHost = endpoint.getHost();
-        boolean loopback = "localhost".equals(endpointHost)
-                || "::1".equals(endpointHost)
-                || (endpointHost != null && endpointHost.startsWith("127."));
+        String normalizedEndpointHost = endpointHost != null
+                && endpointHost.startsWith("[") && endpointHost.endsWith("]")
+                ? endpointHost.substring(1, endpointHost.length() - 1)
+                : endpointHost;
+        String octet = "(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)";
+        boolean numericIpv4Loopback = normalizedEndpointHost != null
+                && normalizedEndpointHost.matches("127\\." + octet + "\\." + octet + "\\." + octet);
+        boolean loopback = "localhost".equals(normalizedEndpointHost)
+                || "::1".equals(normalizedEndpointHost)
+                || numericIpv4Loopback;
         if (endpoint.getUserInfo() != null || endpointHost == null
                 || !("https".equals(endpoint.getScheme())
                 || ("http".equals(endpoint.getScheme()) && loopback))) {
             throw new LocalOperationException("Refusing to send credentials to an insecure bearer token endpoint.");
         }
+
+        String endpointPath = endpoint.getPath();
+        String tokenPath = (endpointPath.endsWith("/") ? endpointPath : endpointPath + "/") + "token";
 
         okhttp3.FormBody.Builder form = new okhttp3.FormBody.Builder();
         if (options != null && options.get("aud") != null) {
@@ -1249,7 +1259,7 @@ public class Transloadit {
         String credentials = java.util.Base64.getEncoder().encodeToString(
                 (this.key + ":" + this.secret).getBytes(java.nio.charset.StandardCharsets.UTF_8));
         okhttp3.Request request = new okhttp3.Request.Builder()
-                .url(endpoint.resolve("/token").toString())
+                .url(endpoint.resolve(tokenPath).toString())
                 .post(form.build())
                 .addHeader("Accept", "application/json")
                 .addHeader("Authorization", "Basic " + credentials)

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -608,7 +608,7 @@ public class Transloadit {
     public AssemblyResponse getAssemblyByUrl(String url)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new AssemblyResponse(request.get(url));
+        return new AssemblyResponse(request.requestAssemblyUrl(url, "GET"));
     }
 
     // </api2-generated-endpoint getAssemblyStatus:urlAlternative>
@@ -669,7 +669,7 @@ public class Transloadit {
     public AssemblyResponse cancelAssembly(String url)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new AssemblyResponse(request.delete(url, new HashMap<String, Object>()));
+        return new AssemblyResponse(request.requestAssemblyUrl(url, "DELETE"));
     }
 
     // </api2-generated-endpoint cancelAssembly>

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -471,7 +471,11 @@ public class Transloadit {
             uploadResponse.close();
         }
 
-        AssemblyResponse completedAssembly = waitForAssembly(createdAssembly.getSslUrl());
+        String createdAssemblyAssemblySslUrl = createdAssembly.getSslUrl();
+        if (createdAssemblyAssemblySslUrl == null || createdAssemblyAssemblySslUrl.isEmpty()) {
+            throw new LocalOperationException("uploadTusAssembly needs createdAssembly.assembly_ssl_url");
+        }
+        AssemblyResponse completedAssembly = waitForAssembly(createdAssemblyAssemblySslUrl);
 
         return new UploadTusAssemblyResult(completedAssembly, uploadUrlText);
     }

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -349,8 +349,7 @@ public class Transloadit {
     // belongs in the contract generator so all SDKs stay in sync.
 
     /**
-     * Creates a TUS-ready Assembly that waits for the requested number of resumable uploads
-     * before execution continues.
+     * Creates a TUS-ready Assembly that waits for the requested number of resumable uploads before execution continues.
      */
     public AssemblyResponse createTusAssembly(int fileCount)
             throws RequestException, LocalOperationException {
@@ -378,7 +377,7 @@ public class Transloadit {
     // belongs in the contract generator so all SDKs stay in sync.
 
     /**
-     * Create a TUS-ready Assembly, upload one file with the TUS protocol, and wait for the Assembly to finish.
+     * Creates a TUS-ready Assembly, uploads one file with the TUS protocol, and waits for the Assembly to finish.
      */
     public UploadTusAssemblyResult uploadTusAssembly(int fileCount, byte[] content, String fieldname, String filename, Map<String, String> userMeta)
             throws RequestException, LocalOperationException {
@@ -529,8 +528,8 @@ public class Transloadit {
     // belongs in the contract generator so all SDKs stay in sync.
 
     /**
-     * Wait for an Assembly to finish uploading and executing.
-     * The assembly URL should be the assembly_ssl_url returned by createAssembly.
+     * Waits for an Assembly to finish uploading and executing.
+     * Use the returned assembly_ssl_url as the assembly URL.
      */
     public AssemblyResponse waitForAssembly(String assemblyUrl)
             throws RequestException, LocalOperationException {

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -396,7 +396,7 @@ public class Transloadit {
                 metadataMap.put(entry.getKey(), entry.getValue());
             }
         }
-        metadataMap.put("assembly_url", String.valueOf(createdAssembly.getUrl()));
+        metadataMap.put("assembly_url", String.valueOf(createdAssembly.getSslUrl()));
         metadataMap.put("fieldname", String.valueOf(fieldname));
         metadataMap.put("filename", String.valueOf(filename));
 

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -370,6 +370,94 @@ public class Transloadit {
 
     // </api2-generated-feature createTusAssembly>
 
+    // <api2-generated-feature resumeTusUpload>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    /**
+     * Resumes an interrupted TUS upload from the server-reported offset and waits for the Assembly to finish.
+     */
+    public AssemblyResponse resumeTusUpload(String uploadUrl, byte[] content, String assemblySslUrl)
+            throws RequestException, LocalOperationException {
+        java.net.URL storedUploadUrl;
+        try {
+            storedUploadUrl = new java.net.URL(uploadUrl);
+        } catch (java.net.MalformedURLException error) {
+            throw new LocalOperationException(error);
+        }
+
+        okhttp3.OkHttpClient httpClient = new okhttp3.OkHttpClient();
+
+        int resumeOffset;
+        okhttp3.Request.Builder offsetRequestBuilder = new okhttp3.Request.Builder()
+                .url(storedUploadUrl)
+                .method("HEAD", null);
+        offsetRequestBuilder.addHeader("Tus-Resumable", "1.0.0");
+        okhttp3.Request offsetRequest = offsetRequestBuilder.build();
+
+        okhttp3.Response offsetResponse;
+        try {
+            offsetResponse = httpClient.newCall(offsetRequest).execute();
+        } catch (java.io.IOException error) {
+            throw new RequestException(error);
+        }
+        try {
+            if (offsetResponse.code() != 200) {
+                throw new RequestException(String.format("TUS offset returned HTTP %d, expected 200", offsetResponse.code()));
+            }
+            String resumeOffsetHeader = offsetResponse.header("Upload-Offset");
+            if (resumeOffsetHeader == null || resumeOffsetHeader.isEmpty()) {
+                throw new RequestException("TUS offset did not return a Upload-Offset header");
+            }
+            try {
+                resumeOffset = Integer.parseInt(resumeOffsetHeader);
+            } catch (NumberFormatException error) {
+                throw new RequestException("TUS offset returned an invalid Upload-Offset header");
+            }
+        } finally {
+            offsetResponse.close();
+        }
+
+        okhttp3.Request.Builder uploadRequestBuilder = new okhttp3.Request.Builder()
+                .url(storedUploadUrl)
+                .method("PATCH", okhttp3.RequestBody.create(null, java.util.Arrays.copyOfRange(content, resumeOffset, content.length)));
+        uploadRequestBuilder.addHeader("Tus-Resumable", "1.0.0");
+        uploadRequestBuilder.addHeader("Upload-Offset", String.valueOf(resumeOffset));
+        uploadRequestBuilder.addHeader("Content-Type", "application/offset+octet-stream");
+        okhttp3.Request uploadRequest = uploadRequestBuilder.build();
+
+        okhttp3.Response uploadResponse;
+        try {
+            uploadResponse = httpClient.newCall(uploadRequest).execute();
+        } catch (java.io.IOException error) {
+            throw new RequestException(error);
+        }
+        try {
+            if (uploadResponse.code() != 204) {
+                throw new RequestException(String.format("TUS upload returned HTTP %d, expected 204", uploadResponse.code()));
+            }
+            int uploadOffset;
+            try {
+                uploadOffset = Integer.parseInt(uploadResponse.header("Upload-Offset"));
+            } catch (NumberFormatException error) {
+                throw new LocalOperationException(error);
+            }
+            if (uploadOffset != content.length) {
+                throw new RequestException(String.format("TUS upload offset %d, expected %d", uploadOffset, content.length));
+            }
+        } finally {
+            uploadResponse.close();
+        }
+
+        AssemblyResponse completedAssembly = waitForAssembly(assemblySslUrl);
+
+        return completedAssembly;
+    }
+
+    // </api2-generated-feature resumeTusUpload>
+
     // <api2-generated-feature uploadTusAssembly>
 
     // This block is generated from Transloadit API2 contracts. If it looks wrong,

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -419,6 +419,29 @@ public class Transloadit {
     }
 
     /**
+     * Creates a template.
+     *
+     * @param options a Map of options to create.
+     * @return {@link Response}
+     *
+     * @throws RequestException if request to transloadit server fails.
+     * @throws LocalOperationException if something goes wrong while running non-http operations.
+     */
+    // <api2-generated-endpoint createTemplate>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public Response createTemplate(Map<String, Object> options)
+            throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new Response(request.post("/templates", options));
+    }
+
+    // </api2-generated-endpoint createTemplate>
+
+    /**
      * Returns a single template.
      *
      * @param id id of the template to retrieve.

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -586,7 +586,7 @@ public class Transloadit {
 
     public AssemblyResponse getAssembly(String id) throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new AssemblyResponse(request.get("/assemblies/" + id));
+        return new AssemblyResponse(request.get("/assemblies/" + request.encodePathSegment(id)));
     }
 
     // </api2-generated-endpoint getAssemblyStatus>
@@ -756,7 +756,7 @@ public class Transloadit {
 
     public Response getTemplate(String id) throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new Response(request.get("/templates/" + id));
+        return new Response(request.get("/templates/" + request.encodePathSegment(id)));
     }
 
     // </api2-generated-endpoint getTemplate>
@@ -780,7 +780,7 @@ public class Transloadit {
     public Response updateTemplate(String id, Map<String, Object> options)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new Response(request.put("/templates/" + id, options));
+        return new Response(request.put("/templates/" + request.encodePathSegment(id), options));
     }
 
     // </api2-generated-endpoint updateTemplate>
@@ -803,7 +803,7 @@ public class Transloadit {
     public Response deleteTemplate(String id)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new Response(request.delete("/templates/" + id, new HashMap<String, Object>()));
+        return new Response(request.delete("/templates/" + request.encodePathSegment(id), new HashMap<String, Object>()));
     }
 
     // </api2-generated-endpoint deleteTemplate>
@@ -998,7 +998,7 @@ public class Transloadit {
     public Response createAssemblyWithId(String assemblyId, Map<String, Object> options, Map<String, String> extraData)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new Response(request.post("/assemblies/" + assemblyId, options, extraData, null, null));
+        return new Response(request.post("/assemblies/" + request.encodePathSegment(assemblyId), options, extraData, null, null));
     }
 
     // </api2-generated-endpoint createAssemblyWithId>
@@ -1013,7 +1013,7 @@ public class Transloadit {
     public Response replayAssembly(String assemblyId, Map<String, Object> options)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new Response(request.post("/assemblies/" + assemblyId + "/replay", options));
+        return new Response(request.post("/assemblies/" + request.encodePathSegment(assemblyId) + "/replay", options));
     }
 
     // </api2-generated-endpoint replayAssembly>
@@ -1028,7 +1028,7 @@ public class Transloadit {
     public Response replayAssemblyNotification(String assemblyId, Map<String, Object> options)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new Response(request.post("/assembly_notifications/" + assemblyId + "/replay", options));
+        return new Response(request.post("/assembly_notifications/" + request.encodePathSegment(assemblyId) + "/replay", options));
     }
 
     // </api2-generated-endpoint replayAssemblyNotification>
@@ -1042,7 +1042,7 @@ public class Transloadit {
 
     public Response listAssemblyNotifications(String assemblyId) throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new Response(request.get("/assembly_notifications/" + assemblyId));
+        return new Response(request.get("/assembly_notifications/" + request.encodePathSegment(assemblyId)));
     }
 
     // </api2-generated-endpoint listAssemblyNotifications>
@@ -1056,7 +1056,7 @@ public class Transloadit {
 
     public Response getBuiltinTemplate(String builtinTemplateSlug) throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new Response(request.get("/templates/builtin/" + builtinTemplateSlug));
+        return new Response(request.get("/templates/builtin/" + request.encodePathSegment(builtinTemplateSlug)));
     }
 
     // </api2-generated-endpoint getBuiltinTemplate>
@@ -1070,7 +1070,7 @@ public class Transloadit {
 
     public Response getTemplateFull(String templateIdOrName) throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new Response(request.get("/templates/" + templateIdOrName + "/full"));
+        return new Response(request.get("/templates/" + request.encodePathSegment(templateIdOrName) + "/full"));
     }
 
     // </api2-generated-endpoint getTemplateFull>
@@ -1084,7 +1084,7 @@ public class Transloadit {
 
     public Response getBuiltinTemplateFull(String builtinTemplateSlug) throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new Response(request.get("/templates/builtin/" + builtinTemplateSlug + "/full"));
+        return new Response(request.get("/templates/builtin/" + request.encodePathSegment(builtinTemplateSlug) + "/full"));
     }
 
     // </api2-generated-endpoint getBuiltinTemplateFull>
@@ -1173,7 +1173,7 @@ public class Transloadit {
 
     public Response getTemplateCredentials(String identifier) throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new Response(request.get("/template_credentials/" + identifier));
+        return new Response(request.get("/template_credentials/" + request.encodePathSegment(identifier)));
     }
 
     // </api2-generated-endpoint getTemplateCredentials>
@@ -1188,7 +1188,7 @@ public class Transloadit {
     public Response deleteTemplateCredentials(String identifier)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new Response(request.delete("/template_credentials/" + identifier, new HashMap<String, Object>()));
+        return new Response(request.delete("/template_credentials/" + request.encodePathSegment(identifier), new HashMap<String, Object>()));
     }
 
     // </api2-generated-endpoint deleteTemplateCredentials>
@@ -1203,7 +1203,7 @@ public class Transloadit {
     public Response updateTemplateCredentials(String identifier, Map<String, Object> options)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new Response(request.put("/template_credentials/" + identifier, options));
+        return new Response(request.put("/template_credentials/" + request.encodePathSegment(identifier), options));
     }
 
     // </api2-generated-endpoint updateTemplateCredentials>
@@ -1287,7 +1287,7 @@ public class Transloadit {
     public Response getBillForInvoice(String date, String invoiceId)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
-        return new Response(request.get("/bill/" + date + "/" + invoiceId));
+        return new Response(request.get("/bill/" + request.encodePathSegment(date) + "/" + request.encodePathSegment(invoiceId)));
     }
 
     // </api2-generated-endpoint getBillForInvoice>

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -371,6 +371,114 @@ public class Transloadit {
 
     // </api2-generated-feature createTusAssembly>
 
+    // <api2-generated-feature uploadTusAssembly>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    /**
+     * Create a TUS-ready Assembly, upload one file with the TUS protocol, and wait for the Assembly to finish.
+     */
+    public UploadTusAssemblyResult uploadTusAssembly(int fileCount, byte[] content, String fieldname, String filename, Map<String, String> userMeta)
+            throws RequestException, LocalOperationException {
+        AssemblyResponse createdAssembly = createTusAssembly(fileCount);
+
+        java.net.URL endpointUrl;
+        try {
+            endpointUrl = new java.net.URL(createdAssembly.getTusUrl());
+        } catch (java.net.MalformedURLException error) {
+            throw new LocalOperationException(error);
+        }
+
+        Map<String, String> metadataMap = new HashMap<String, String>();
+        if (userMeta != null) {
+            for (Map.Entry<String, String> entry : userMeta.entrySet()) {
+                metadataMap.put(entry.getKey(), entry.getValue());
+            }
+        }
+        metadataMap.put("assembly_url", String.valueOf(createdAssembly.getUrl()));
+        metadataMap.put("fieldname", String.valueOf(fieldname));
+        metadataMap.put("filename", String.valueOf(filename));
+
+        okhttp3.OkHttpClient httpClient = new okhttp3.OkHttpClient();
+
+        String uploadUrlText;
+        okhttp3.Request.Builder createRequestBuilder = new okhttp3.Request.Builder()
+                .url(endpointUrl)
+                .method("POST", okhttp3.RequestBody.create(null, new byte[0]));
+        createRequestBuilder.addHeader("Tus-Resumable", "1.0.0");
+        createRequestBuilder.addHeader("Upload-Length", String.valueOf(content.length));
+        List<String> createMetadataParts = new ArrayList<String>();
+        for (Map.Entry<String, String> entry : metadataMap.entrySet()) {
+            createMetadataParts.add(entry.getKey() + " " + java.util.Base64.getEncoder().encodeToString(entry.getValue().getBytes(StandardCharsets.UTF_8)));
+        }
+        createRequestBuilder.addHeader("Upload-Metadata", String.join(",", createMetadataParts));
+        okhttp3.Request createRequest = createRequestBuilder.build();
+
+        okhttp3.Response createResponse;
+        try {
+            createResponse = httpClient.newCall(createRequest).execute();
+        } catch (java.io.IOException error) {
+            throw new RequestException(error);
+        }
+        try {
+            if (createResponse.code() != 201) {
+                throw new RequestException(String.format("TUS create returned HTTP %d, expected 201", createResponse.code()));
+            }
+            String uploadUrlLocation = createResponse.header("Location");
+            if (uploadUrlLocation == null || uploadUrlLocation.isEmpty()) {
+                throw new RequestException("TUS create did not return a Location header");
+            }
+            java.net.URL uploadUrl;
+            try {
+                uploadUrl = new java.net.URL(endpointUrl, uploadUrlLocation);
+            } catch (java.net.MalformedURLException error) {
+                throw new LocalOperationException(error);
+            }
+            uploadUrlText = uploadUrl.toString();
+        } finally {
+            createResponse.close();
+        }
+
+        okhttp3.Request.Builder uploadRequestBuilder = new okhttp3.Request.Builder()
+                .url(uploadUrlText)
+                .method("PATCH", okhttp3.RequestBody.create(null, content));
+        uploadRequestBuilder.addHeader("Tus-Resumable", "1.0.0");
+        uploadRequestBuilder.addHeader("Upload-Offset", "0");
+        uploadRequestBuilder.addHeader("Content-Type", "application/offset+octet-stream");
+        okhttp3.Request uploadRequest = uploadRequestBuilder.build();
+
+        okhttp3.Response uploadResponse;
+        try {
+            uploadResponse = httpClient.newCall(uploadRequest).execute();
+        } catch (java.io.IOException error) {
+            throw new RequestException(error);
+        }
+        try {
+            if (uploadResponse.code() != 204) {
+                throw new RequestException(String.format("TUS upload returned HTTP %d, expected 204", uploadResponse.code()));
+            }
+            int remoteOffset;
+            try {
+                remoteOffset = Integer.parseInt(uploadResponse.header("Upload-Offset"));
+            } catch (NumberFormatException error) {
+                throw new LocalOperationException(error);
+            }
+            if (remoteOffset != content.length) {
+                throw new RequestException(String.format("TUS upload offset %d, expected %d", remoteOffset, content.length));
+            }
+        } finally {
+            uploadResponse.close();
+        }
+
+        AssemblyResponse completedAssembly = waitForAssembly(createdAssembly.getSslUrl());
+
+        return new UploadTusAssemblyResult(completedAssembly, uploadUrlText);
+    }
+
+    // </api2-generated-feature uploadTusAssembly>
+
     /**
      * Returns a single assembly.
      *

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -327,10 +327,18 @@ public class Transloadit {
      * @throws RequestException if request to transloadit server fails.
      * @throws LocalOperationException if something goes wrong while running non-http operations.
      */
+    // <api2-generated-endpoint getAssemblyStatus>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
     public AssemblyResponse getAssembly(String id) throws RequestException, LocalOperationException {
         Request request = new Request(this);
         return new AssemblyResponse(request.get("/assemblies/" + id));
     }
+
+    // </api2-generated-endpoint getAssemblyStatus>
 
     /**
      * Returns a single assembly.
@@ -354,11 +362,19 @@ public class Transloadit {
      * @throws RequestException if request to transloadit server fails.
      * @throws LocalOperationException if something goes wrong while running non-http operations.
      */
+    // <api2-generated-endpoint cancelAssembly>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
     public AssemblyResponse cancelAssembly(String url)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
         return new AssemblyResponse(request.delete(url, new HashMap<String, Object>()));
     }
+
+    // </api2-generated-endpoint cancelAssembly>
 
     /**
      * Returns a list of all assemblies under the user account.
@@ -368,11 +384,19 @@ public class Transloadit {
      * @throws RequestException if request to transloadit server fails.
      * @throws LocalOperationException if something goes wrong while running non-http operations.
      */
+    // <api2-generated-endpoint listAssemblies>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
     public ListResponse listAssemblies(Map<String, Object> options)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
         return new ListResponse(request.get("/assemblies", options));
     }
+
+    // </api2-generated-endpoint listAssemblies>
 
     /**
      * Returns a list of all assemblies under the user account.
@@ -403,10 +427,18 @@ public class Transloadit {
      * @throws RequestException if request to transloadit server fails.
      * @throws LocalOperationException if something goes wrong while running non-http operations.
      */
+    // <api2-generated-endpoint getTemplate>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
     public Response getTemplate(String id) throws RequestException, LocalOperationException {
         Request request = new Request(this);
         return new Response(request.get("/templates/" + id));
     }
+
+    // </api2-generated-endpoint getTemplate>
 
     /**
      * Updates the template with the specified id.
@@ -418,11 +450,19 @@ public class Transloadit {
      * @throws RequestException if request to transloadit server fails.
      * @throws LocalOperationException if something goes wrong while running non-http operations.
      */
+    // <api2-generated-endpoint updateTemplate>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
     public Response updateTemplate(String id, Map<String, Object> options)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
         return new Response(request.put("/templates/" + id, options));
     }
+
+    // </api2-generated-endpoint updateTemplate>
 
     /**
      * Deletes a template.
@@ -433,11 +473,19 @@ public class Transloadit {
      * @throws RequestException if request to transloadit server fails.
      * @throws LocalOperationException if something goes wrong while running non-http operations.
      */
+    // <api2-generated-endpoint deleteTemplate>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
     public Response deleteTemplate(String id)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
         return new Response(request.delete("/templates/" + id, new HashMap<String, Object>()));
     }
+
+    // </api2-generated-endpoint deleteTemplate>
 
     /**
      * Returns a list of all templates under the user account.
@@ -448,11 +496,19 @@ public class Transloadit {
      * @throws RequestException if request to transloadit server fails.
      * @throws LocalOperationException if something goes wrong while running non-http operations.
      */
+    // <api2-generated-endpoint listTemplates>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
     public ListResponse listTemplates(Map<String, Object> options)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
         return new ListResponse(request.get("/templates", options));
     }
+
+    // </api2-generated-endpoint listTemplates>
 
     /**
      * Returns a list of all templates under the user account.
@@ -477,11 +533,19 @@ public class Transloadit {
      * @throws RequestException if request to transloadit server fails.
      * @throws LocalOperationException if something goes wrong while running non-http operations.
      */
+    // <api2-generated-endpoint getBill>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
     public Response getBill(int month, int year)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
         return new Response(request.get("/bill/" + year + String.format("-%02d", month)));
     }
+
+    // </api2-generated-endpoint getBill>
 
     /**
      * Returns Array List of String encoded Exceptions, which should be qualified for a retry attempt.

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -467,9 +467,9 @@ public class Transloadit {
     /**
      * Creates a TUS-ready Assembly, uploads one file with the TUS protocol, and waits for the Assembly to finish.
      */
-    public UploadTusAssemblyResult uploadTusAssembly(int fileCount, byte[] content, String fieldname, String filename, Map<String, String> userMeta)
+    public UploadTusAssemblyResult uploadTusAssembly(byte[] content, String fieldname, String filename, Map<String, String> userMeta)
             throws RequestException, LocalOperationException {
-        AssemblyResponse createdAssembly = createTusAssembly(fileCount);
+        AssemblyResponse createdAssembly = createTusAssembly(1);
 
         java.net.URL endpointUrl;
         try {

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -1277,4 +1277,19 @@ public class Transloadit {
 
     // </api2-generated-endpoint issueBearerToken>
 
+
+    // <api2-generated-endpoint getBillForInvoice>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public Response getBillForInvoice(String date, String invoiceId)
+            throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new Response(request.get("/bill/" + date + "/" + invoiceId));
+    }
+
+    // </api2-generated-endpoint getBillForInvoice>
+
 }

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -400,11 +400,58 @@ public class Transloadit {
      * @throws RequestException if request to transloadit server fails.
      * @throws LocalOperationException if something goes wrong while running non-http operations.
      */
+    // <api2-generated-endpoint getAssemblyStatus:urlAlternative>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
     public AssemblyResponse getAssemblyByUrl(String url)
             throws RequestException, LocalOperationException {
         Request request = new Request(this);
         return new AssemblyResponse(request.get(url));
     }
+
+    // </api2-generated-endpoint getAssemblyStatus:urlAlternative>
+
+    // <api2-generated-feature waitForAssembly>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    /**
+     * Wait for an Assembly to finish uploading and executing.
+     * The assembly URL should be the assembly_ssl_url returned by createAssembly.
+     */
+    public AssemblyResponse waitForAssembly(String assemblyUrl)
+            throws RequestException, LocalOperationException {
+        List<String> responsePollValues = java.util.Arrays.asList(
+                "ASSEMBLY_UPLOADING", "ASSEMBLY_EXECUTING");
+        while (true) {
+            AssemblyResponse response = getAssemblyByUrl(assemblyUrl);
+            org.json.JSONObject responseJson = response.json();
+
+            // Abort polling if the assembly has entered an error state
+            if (!responseJson.optString("error").isEmpty()) {
+                return response;
+            }
+
+            // The polling is done if the assembly is not uploading or executing anymore.
+            if (!(responsePollValues.contains(responseJson.optString("ok")))) {
+                return response;
+            }
+
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException error) {
+                Thread.currentThread().interrupt();
+                throw new LocalOperationException(error);
+            }
+        }
+    }
+
+    // </api2-generated-feature waitForAssembly>
 
     /**
      * cancels a running assembly.

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -1208,4 +1208,63 @@ public class Transloadit {
 
     // </api2-generated-endpoint updateTemplateCredentials>
 
+
+    // <api2-generated-endpoint issueBearerToken>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public Response issueBearerToken(Map<String, String> options)
+            throws RequestException, LocalOperationException {
+        if (this.secret == null) {
+            throw new LocalOperationException("Bearer token issuance requires an auth secret.");
+        }
+
+        java.net.URI endpoint;
+        try {
+            endpoint = java.net.URI.create(this.getHostUrl());
+        } catch (IllegalArgumentException error) {
+            throw new LocalOperationException("Invalid bearer token endpoint.", error);
+        }
+        String endpointHost = endpoint.getHost();
+        boolean loopback = "localhost".equals(endpointHost)
+                || "::1".equals(endpointHost)
+                || (endpointHost != null && endpointHost.startsWith("127."));
+        if (endpoint.getUserInfo() != null || endpointHost == null
+                || !("https".equals(endpoint.getScheme())
+                || ("http".equals(endpoint.getScheme()) && loopback))) {
+            throw new LocalOperationException("Refusing to send credentials to an insecure bearer token endpoint.");
+        }
+
+        okhttp3.FormBody.Builder form = new okhttp3.FormBody.Builder();
+        if (options != null && options.get("aud") != null) {
+            form.add("aud", options.get("aud"));
+        }
+        form.add("grant_type", "client_credentials");
+        if (options != null && options.get("scope") != null) {
+            form.add("scope", options.get("scope"));
+        }
+
+        String credentials = java.util.Base64.getEncoder().encodeToString(
+                (this.key + ":" + this.secret).getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        okhttp3.Request request = new okhttp3.Request.Builder()
+                .url(endpoint.resolve("/token").toString())
+                .post(form.build())
+                .addHeader("Accept", "application/json")
+                .addHeader("Authorization", "Basic " + credentials)
+                .addHeader("Transloadit-Client", this.versionInfo)
+                .build();
+        okhttp3.OkHttpClient client = new okhttp3.OkHttpClient.Builder()
+                .followRedirects(false)
+                .build();
+        try {
+            return new Response(client.newCall(request).execute());
+        } catch (java.io.IOException error) {
+            throw new RequestException(error);
+        }
+    }
+
+    // </api2-generated-endpoint issueBearerToken>
+
 }

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -459,14 +459,14 @@ public class Transloadit {
             if (uploadResponse.code() != 204) {
                 throw new RequestException(String.format("TUS upload returned HTTP %d, expected 204", uploadResponse.code()));
             }
-            int remoteOffset;
+            int uploadOffset;
             try {
-                remoteOffset = Integer.parseInt(uploadResponse.header("Upload-Offset"));
+                uploadOffset = Integer.parseInt(uploadResponse.header("Upload-Offset"));
             } catch (NumberFormatException error) {
                 throw new LocalOperationException(error);
             }
-            if (remoteOffset != content.length) {
-                throw new RequestException(String.format("TUS upload offset %d, expected %d", remoteOffset, content.length));
+            if (uploadOffset != content.length) {
+                throw new RequestException(String.format("TUS upload offset %d, expected %d", uploadOffset, content.length));
             }
         } finally {
             uploadResponse.close();

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -320,6 +320,29 @@ public class Transloadit {
     }
 
     /**
+     * Creates an assembly.
+     *
+     * @param options a Map of options to create.
+     * @param extraData extra form data to create the assembly with.
+     * @return {@link AssemblyResponse}
+     * @throws RequestException if request to transloadit server fails.
+     * @throws LocalOperationException if something goes wrong while running non-http operations.
+     */
+    // <api2-generated-endpoint createAssembly>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public AssemblyResponse createAssembly(Map<String, Object> options, Map<String, String> extraData)
+            throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new AssemblyResponse(request.post("/assemblies", options, extraData, null, null));
+    }
+
+    // </api2-generated-endpoint createAssembly>
+
+    /**
      * Returns a single assembly.
      *
      * @param id id of the Assembly to retrieve.

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -342,6 +342,35 @@ public class Transloadit {
 
     // </api2-generated-endpoint createAssembly>
 
+    // <api2-generated-feature createTusAssembly>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    /**
+     * Creates a TUS-ready Assembly that waits for the requested number of resumable uploads
+     * before execution continues.
+     */
+    public AssemblyResponse createTusAssembly(int fileCount)
+            throws RequestException, LocalOperationException {
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put("await", false);
+        Map<String, Object> optionsSteps = new HashMap<String, Object>();
+        Map<String, Object> optionsStepsOriginal = new HashMap<String, Object>();
+        optionsStepsOriginal.put("output_meta", true);
+        optionsStepsOriginal.put("result", "debug");
+        optionsStepsOriginal.put("robot", "/upload/handle");
+        optionsSteps.put(":original", optionsStepsOriginal);
+        options.put("steps", optionsSteps);
+        Map<String, String> extraData = new HashMap<String, String>();
+        extraData.put("num_expected_upload_files", String.valueOf(fileCount));
+
+        return createAssembly(options, extraData);
+    }
+
+    // </api2-generated-feature createTusAssembly>
+
     /**
      * Returns a single assembly.
      *

--- a/src/main/java/com/transloadit/sdk/Transloadit.java
+++ b/src/main/java/com/transloadit/sdk/Transloadit.java
@@ -988,4 +988,224 @@ public class Transloadit {
             throw new LocalOperationException("Failed to create signature: " + e.getMessage());
         }
     }
+
+    // <api2-generated-endpoint createAssemblyWithId>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public Response createAssemblyWithId(String assemblyId, Map<String, Object> options, Map<String, String> extraData)
+            throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new Response(request.post("/assemblies/" + assemblyId, options, extraData, null, null));
+    }
+
+    // </api2-generated-endpoint createAssemblyWithId>
+
+
+    // <api2-generated-endpoint replayAssembly>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public Response replayAssembly(String assemblyId, Map<String, Object> options)
+            throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new Response(request.post("/assemblies/" + assemblyId + "/replay", options));
+    }
+
+    // </api2-generated-endpoint replayAssembly>
+
+
+    // <api2-generated-endpoint replayAssemblyNotification>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public Response replayAssemblyNotification(String assemblyId, Map<String, Object> options)
+            throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new Response(request.post("/assembly_notifications/" + assemblyId + "/replay", options));
+    }
+
+    // </api2-generated-endpoint replayAssemblyNotification>
+
+
+    // <api2-generated-endpoint listAssemblyNotifications>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public Response listAssemblyNotifications(String assemblyId) throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new Response(request.get("/assembly_notifications/" + assemblyId));
+    }
+
+    // </api2-generated-endpoint listAssemblyNotifications>
+
+
+    // <api2-generated-endpoint getBuiltinTemplate>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public Response getBuiltinTemplate(String builtinTemplateSlug) throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new Response(request.get("/templates/builtin/" + builtinTemplateSlug));
+    }
+
+    // </api2-generated-endpoint getBuiltinTemplate>
+
+
+    // <api2-generated-endpoint getTemplateFull>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public Response getTemplateFull(String templateIdOrName) throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new Response(request.get("/templates/" + templateIdOrName + "/full"));
+    }
+
+    // </api2-generated-endpoint getTemplateFull>
+
+
+    // <api2-generated-endpoint getBuiltinTemplateFull>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public Response getBuiltinTemplateFull(String builtinTemplateSlug) throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new Response(request.get("/templates/builtin/" + builtinTemplateSlug + "/full"));
+    }
+
+    // </api2-generated-endpoint getBuiltinTemplateFull>
+
+
+    // <api2-generated-endpoint listPriorityJobSlots>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public ListResponse listPriorityJobSlots(Map<String, Object> options)
+            throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new ListResponse(request.get("/queues/job_slots", options));
+    }
+
+    // </api2-generated-endpoint listPriorityJobSlots>
+
+
+    // <api2-generated-endpoint listTemplateCredentials>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public ListResponse listTemplateCredentials(Map<String, Object> options)
+            throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new ListResponse(request.get("/template_credentials", options));
+    }
+
+    // </api2-generated-endpoint listTemplateCredentials>
+
+
+    // <api2-generated-endpoint listTemplateCredentialTypes>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public ListResponse listTemplateCredentialTypes(Map<String, Object> options)
+            throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new ListResponse(request.get("/template_credentials/types", options));
+    }
+
+    // </api2-generated-endpoint listTemplateCredentialTypes>
+
+
+    // <api2-generated-endpoint validateTemplateCredentialOauthOnCreate>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public Response validateTemplateCredentialOauthOnCreate(Map<String, Object> options)
+            throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new Response(request.post("/template_credentials/validateOauthOnCreate", options));
+    }
+
+    // </api2-generated-endpoint validateTemplateCredentialOauthOnCreate>
+
+
+    // <api2-generated-endpoint createTemplateCredentials>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public Response createTemplateCredentials(Map<String, Object> options)
+            throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new Response(request.post("/template_credentials", options));
+    }
+
+    // </api2-generated-endpoint createTemplateCredentials>
+
+
+    // <api2-generated-endpoint getTemplateCredentials>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public Response getTemplateCredentials(String identifier) throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new Response(request.get("/template_credentials/" + identifier));
+    }
+
+    // </api2-generated-endpoint getTemplateCredentials>
+
+
+    // <api2-generated-endpoint deleteTemplateCredentials>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public Response deleteTemplateCredentials(String identifier)
+            throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new Response(request.delete("/template_credentials/" + identifier, new HashMap<String, Object>()));
+    }
+
+    // </api2-generated-endpoint deleteTemplateCredentials>
+
+
+    // <api2-generated-endpoint updateTemplateCredentials>
+
+    // This block is generated from Transloadit API2 contracts. If it looks wrong,
+    // please report the issue instead of editing this block by hand; the source fix
+    // belongs in the contract generator so all SDKs stay in sync.
+
+    public Response updateTemplateCredentials(String identifier, Map<String, Object> options)
+            throws RequestException, LocalOperationException {
+        Request request = new Request(this);
+        return new Response(request.put("/template_credentials/" + identifier, options));
+    }
+
+    // </api2-generated-endpoint updateTemplateCredentials>
+
 }

--- a/src/main/java/com/transloadit/sdk/UploadTusAssemblyResult.java
+++ b/src/main/java/com/transloadit/sdk/UploadTusAssemblyResult.java
@@ -2,6 +2,10 @@ package com.transloadit.sdk;
 
 import com.transloadit.sdk.response.AssemblyResponse;
 
+// This file is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this file by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
 /**
  * Result returned after uploading one file through a TUS Assembly.
  */

--- a/src/main/java/com/transloadit/sdk/UploadTusAssemblyResult.java
+++ b/src/main/java/com/transloadit/sdk/UploadTusAssemblyResult.java
@@ -1,0 +1,24 @@
+package com.transloadit.sdk;
+
+import com.transloadit.sdk.response.AssemblyResponse;
+
+/**
+ * Result returned after uploading one file through a TUS Assembly.
+ */
+public class UploadTusAssemblyResult {
+    private final AssemblyResponse assembly;
+    private final String uploadUrl;
+
+    public UploadTusAssemblyResult(AssemblyResponse assembly, String uploadUrl) {
+        this.assembly = assembly;
+        this.uploadUrl = uploadUrl;
+    }
+
+    public AssemblyResponse getAssembly() {
+        return assembly;
+    }
+
+    public String getUploadUrl() {
+        return uploadUrl;
+    }
+}

--- a/src/test/java/com/transloadit/sdk/TransloaditTest.java
+++ b/src/test/java/com/transloadit/sdk/TransloaditTest.java
@@ -176,6 +176,20 @@ public class TransloaditTest extends MockHttpService {
 
         Assertions.assertEquals(assembly.getId(), "76fe5df1c93a0a530f3e583805cf98b4");
         Assertions.assertEquals(assembly.getUrl(), "http://localhost:9040/assemblies/76fe5df1c93a0a530f3e583805cf98b4");
+
+        HttpRequest[] recorded = mockServerClient.retrieveRecordedRequests(HttpRequest.request()
+                .withPath("/assemblies/76fe5df1c93a0a530f3e583805cf98b4").withMethod("GET"));
+        Assertions.assertEquals(1, recorded.length);
+        Assertions.assertTrue(recorded[0].getQueryStringParameterList().isEmpty());
+        Assertions.assertNull(recorded[0].getBodyAsString());
+    }
+
+    @Test
+    public void getAssemblyByUrlRejectsUntrustedOrigins() {
+        Assertions.assertThrows(
+                LocalOperationException.class,
+                () -> transloadit.getAssemblyByUrl(
+                        "http://localhost:" + (PORT + 1) + "/assemblies/76fe5df1c93a0a530f3e583805cf98b4"));
     }
 
     /**
@@ -195,6 +209,12 @@ public class TransloaditTest extends MockHttpService {
                 .cancelAssembly(transloadit.getHostUrl() + "/assemblies/76fe5df1c93a0a530f3e583805cf98b4");
 
         Assertions.assertEquals(assembly.json().getString("ok"), "ASSEMBLY_CANCELED");
+
+        HttpRequest[] recorded = mockServerClient.retrieveRecordedRequests(HttpRequest.request()
+                .withPath("/assemblies/76fe5df1c93a0a530f3e583805cf98b4").withMethod("DELETE"));
+        Assertions.assertEquals(1, recorded.length);
+        Assertions.assertTrue(recorded[0].getQueryStringParameterList().isEmpty());
+        Assertions.assertNull(recorded[0].getBodyAsString());
     }
 
     /**

--- a/src/test/java/com/transloadit/sdk/TransloaditTest.java
+++ b/src/test/java/com/transloadit/sdk/TransloaditTest.java
@@ -53,6 +53,28 @@ public class TransloaditTest extends MockHttpService {
         Assertions.assertEquals(transloadit.getHostUrl(), "http://localhost:" + PORT);
     }
 
+    @Test
+    public void issueBearerTokenUsesBasicAuthAndFormEncoding()
+            throws LocalOperationException, RequestException {
+        mockServerClient.when(HttpRequest.request()
+                        .withPath("/token")
+                        .withMethod("POST")
+                        .withHeader("Authorization", "Basic S0VZOlNFQ1JFVA==")
+                        .withHeader("Content-Type", "application/x-www-form-urlencoded")
+                        .withBody("grant_type=client_credentials&scope=assemblies%3Aread"))
+                .respond(HttpResponse.response()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"access_token\":\"abc\",\"expires_in\":21600,"
+                                + "\"scope\":\"assemblies:read\",\"token_type\":\"Bearer\"}"));
+
+        Map<String, String> options = new HashMap<String, String>();
+        options.put("scope", "assemblies:read");
+        Response response = transloadit.issueBearerToken(options);
+
+        Assertions.assertEquals(200, response.status());
+        Assertions.assertEquals("abc", response.json().getString("access_token"));
+    }
+
     /**
      * Tests if {@link Transloadit#getAssembly(String)} returns the specified Assembly's response
      * by verifying the assembly_id and host URL.
@@ -399,4 +421,3 @@ public class TransloaditTest extends MockHttpService {
         Assertions.assertEquals(expectedUrl, url);
     }
 }
-

--- a/src/test/java/com/transloadit/sdk/TransloaditTest.java
+++ b/src/test/java/com/transloadit/sdk/TransloaditTest.java
@@ -75,6 +75,15 @@ public class TransloaditTest extends MockHttpService {
         Assertions.assertEquals("abc", response.json().getString("access_token"));
     }
 
+    @Test
+    public void issueBearerTokenRejects127PrefixedDomain() {
+        Transloadit unsafe = new Transloadit("KEY", "SECRET", "http://127.attacker.com");
+
+        Assertions.assertThrows(
+                LocalOperationException.class,
+                () -> unsafe.issueBearerToken(Collections.<String, String>emptyMap()));
+    }
+
     /**
      * Tests if {@link Transloadit#getAssembly(String)} returns the specified Assembly's response
      * by verifying the assembly_id and host URL.


### PR DESCRIPTION
## Why

API2 now has a Java Transloadit SDK adapter that can mechanically render Java SDK endpoint methods from contract metadata. This companion PR gives that generator real marker regions to rewrite and compare, plus checked-in consumer examples that prove the generated endpoint surface against devdock.

## Experimental Status

Experimental work: this PR is part of the API2 contract/generated SDK effort and is intentionally kept as a Draft while the generated surface and consumer proof examples are validated.

## What changed

- The checked-in TUS Assembly example now reads `createTusAssembly` input from generic `scenario.preparations[]` instead of the removed API2 compatibility field.
- Added API2 generated endpoint markers around Java SDK methods for Assembly create/status/cancel/list, Template create/get/update/delete/list, and Bill retrieval.
- Added an API2 generated feature marker for `Transloadit.createTusAssembly(fileCount)`, which builds the contract-owned TUS Assembly request and delegates to the generated `createAssembly(options, extraData)` endpoint method.
- Added an API2 generated URL endpoint variant marker for `Transloadit.getAssemblyByUrl(url)` and a generated `Transloadit.waitForAssembly(assemblyUrl)` polling feature.
- Kept the existing JavaDoc outside endpoint generated blocks so human-facing SDK docs remain checked in while the mechanical request methods become contract-owned.
- Added hand-written devdock examples for Template lifecycle, TUS Assembly upload, and Assembly lifecycle.
- The new Assembly lifecycle example proves `createTusAssembly`, `getAssemblyByUrl`, `listAssemblies`, and `cancelAssembly` together against API2 devdock using contract-injected scenario JSON.
- Enabled the `examples` Gradle project and added `:examples:api2DevdockTemplateLifecycle`, `:examples:api2DevdockTusAssembly`, and `:examples:api2DevdockAssemblyLifecycle`.
- The generated blocks are owned by API2 contracts; fixes should land in API2 and be regenerated here. The example source is intentionally hand-written SDK repo code, not generated.

## Validation

- From API2: `node api2/bin/cli.ts contracts sdks --no-motd --target transloadit --platform java --sdk-root ../java-sdk --compare-existing`
- From API2: `node api2/bin/cli.ts contracts sdks qa --no-motd --dry-run --target transloadit --platform java --proof-level git-handwritten-examples`
- Java SDK: `./gradlew -q :examples:compileJava`
- Java SDK: `./gradlew check`
- From API2: `core/bin/devdock.ts exec tstrun system/sdk_examples/java-transloadit-examples.test.ts -vv --max-time-per-test 600`

## Companion PRs

### Transloadit

- API2 contract/generator source: https://github.com/transloadit/api2/pull/7928
- Content generated endpoint docs: https://github.com/transloadit/content/pull/5074
- Go SDK generated-region canary: https://github.com/transloadit/go-sdk/pull/45
- Python SDK generated endpoints: https://github.com/transloadit/python-sdk/pull/57
- Node SDK generated high-level feature markers: https://github.com/transloadit/node-sdk/pull/422

### TUS

Allowed outward links from Transloadit to the related tus companion PRs:

- tus-js-client: https://github.com/tus/tus-js-client/pull/872
- tus-go-client: https://github.com/tus/tus-go-client/pull/6
- tus-py-client: https://github.com/tus/tus-py-client/pull/114
- tus-java-client: https://github.com/tus/tus-java-client/pull/149
- tus-android-client: https://github.com/tus/tus-android-client/pull/167
