### PR TITLE
Replace Slack notification action and harden action refs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,8 +62,12 @@ jobs:
       runs-on: ubuntu-latest
 
       steps:
-        - uses: 8398a7/action-slack@v3
-          with:
-            status: failure
+        - name: Send Slack notification
           env:
             SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+            SLACK_TEXT: >-
+              ${{ github.workflow }} failed for ${{ github.repository }} on ${{ github.ref_name }}:
+              ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          run: |
+            node -e "process.stdout.write(JSON.stringify({ text: process.env.SLACK_TEXT }))" |
+              curl --fail-with-body -X POST -H 'Content-type: application/json' --data-binary @- "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,10 @@ jobs:
 
       steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
@@ -37,7 +37,7 @@ jobs:
       # This allows us to test Smart CDN Signatures against the Node SDK reference
       # implementation for parity.
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.java == '11'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Why

Reduce GitHub Actions supply-chain exposure by removing the third-party Slack notification action from the CI failure path.

What changed

- Replaces `8398a7/action-slack` with a direct incoming-webhook `curl` step.
- Keeps notifications scoped to main-branch Java CI failures.

Validation

- Ruby YAML parse for `.github/workflows/tests.yml`
- `git diff --check`

Additional action reference hardening included here:

- Updates GitHub-owned actions in touched workflows to current major tags.
- Pins retained third-party actions in touched workflows to reviewed commit SHAs, keeping version comments beside each SHA.
